### PR TITLE
Add palantir bintray to build repos.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -29,10 +29,13 @@ buildscript {
         maven {
             url 'https://plugins.gradle.org/m2/'
         }
+        maven {
+            url  "http://palantir.bintray.com/releases"
+        }
     }
     dependencies {
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.1.0'
-        classpath 'com.palantir:gradle-baseline-java:0.11.1'
+        classpath 'com.palantir.baseline:gradle-baseline-java:0.12.0'
         classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1'
         classpath 'io.spring.gradle:dependency-management-plugin:1.0.0.RELEASE'
         classpath 'net.ltgt.gradle:gradle-apt-plugin:0.9'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -30,7 +30,7 @@ buildscript {
             url 'https://plugins.gradle.org/m2/'
         }
         maven {
-            url  "http://palantir.bintray.com/releases"
+            url  'http://palantir.bintray.com/releases'
         }
     }
     dependencies {


### PR DESCRIPTION
gradle-baseline-java classpath also updated to reflect the palantir bintray scheme.

While running `gradlew idea` there were unmet dependencies.

Heads up, the version of gradle-baseline-java was bumped to `0.12.0` .