### PR TITLE
Update netty modules to 4.1.19.Final.

### DIFF
--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -193,7 +193,7 @@ class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("io.netty")
-              .version("4.1.17.Final")
+              .version("4.1.19.Final")
               .addModules(
                   "netty-buffer",
                   "netty-codec",


### PR DESCRIPTION
Even after https://github.com/line/armeria/issues/925 was updated, it looks like the netty modules are still on 4.1.17.Final (only common seems to have gotten the bump to 4.1.19).

Here's a list of a container's lib/ directory on 0.0.75

```
netty-buffer-4.1.17.Final.jar
netty-codec-4.1.17.Final.jar
netty-codec-dns-4.1.17.Final.jar
netty-codec-http-4.1.17.Final.jar
netty-codec-http2-4.1.17.Final.jar
netty-codec-socks-4.1.17.Final.jar
netty-common-4.1.17.Final.jar
netty-handler-4.1.17.Final.jar
netty-handler-proxy-4.1.17.Final.jar
netty-resolver-4.1.17.Final.jar
netty-resolver-dns-4.1.17.Final.jar
netty-tcnative-boringssl-static-2.0.7.Final.jar
netty-transport-4.1.17.Final.jar
netty-transport-native-epoll-4.1.17.Final-linux-x86_64.jar
netty-transport-native-unix-common-4.1.19.Final-linux-x86_64.jar
netty-transport-native-unix-common-4.1.19.Final.jar
```