### PR TITLE
Explicitly set the only types package we use so other ones don't get …

### DIFF
--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.101
+version = 0.0.102

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/resources/grpcapi/tsconfig-template.json
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/resources/grpcapi/tsconfig-template.json
@@ -1,6 +1,9 @@
 {
+  "compilerOptions": {
+    "types": ["google-protobuf"]
+  },
   "include": [
-    "./**/*"
+    "**/*"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
…used and cause compile issues.

All `@types` packages are included by default, which can cause problems if the types require extra libraries like dom.

Reverts change to set `includes` to a relative path as it did actually work only relative to the current directory either way.