### PR TITLE
Enable graceful shutdown, support wildcard ingress paths, and don't validate

### DIFF
--- a/common/server/framework/gradle.properties
+++ b/common/server/framework/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.52
+version = 0.0.53

--- a/common/server/framework/gradle.properties
+++ b/common/server/framework/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.53
+version = 0.0.54

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/config/ServerConfig.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/config/ServerConfig.java
@@ -108,4 +108,11 @@ public interface ServerConfig {
    * rules are applied to all requests.
    */
   boolean getIpFilterInternalOnly();
+
+  /**
+   * Sets whether to shutdown gracefully, by first disabling health check and then wait some time
+   * for requests to go away before shutting down. This should always be set in non-local
+   * deployments.
+   */
+  boolean getEnableGracefulShutdown();
 }

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/redis/RedisModule.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/redis/RedisModule.java
@@ -50,9 +50,7 @@ public abstract class RedisModule {
   @Singleton
   static RedisClusterClient redisClient(RedisConfig config) {
     RedisClusterClient client = RedisClusterClient.create(config.getUrl());
-    client.setOptions(ClusterClientOptions.builder()
-        .validateClusterNodeMembership(false)
-        .build());
+    client.setOptions(ClusterClientOptions.builder().validateClusterNodeMembership(false).build());
     return client;
   }
 

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/redis/RedisModule.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/redis/RedisModule.java
@@ -29,6 +29,7 @@ import com.typesafe.config.ConfigBeanFactory;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
+import io.lettuce.core.cluster.ClusterClientOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import javax.inject.Singleton;
 import org.curioswitch.common.server.framework.config.ModifiableRedisConfig;
@@ -48,7 +49,11 @@ public abstract class RedisModule {
   @Provides
   @Singleton
   static RedisClusterClient redisClient(RedisConfig config) {
-    return RedisClusterClient.create(config.getUrl());
+    RedisClusterClient client = RedisClusterClient.create(config.getUrl());
+    client.setOptions(ClusterClientOptions.builder()
+        .validateClusterNodeMembership(false)
+        .build());
+    return client;
   }
 
   @Provides

--- a/common/server/framework/src/main/resources/curio-server-framework-nonlocal.conf
+++ b/common/server/framework/src/main/resources/curio-server-framework-nonlocal.conf
@@ -31,4 +31,5 @@ server {
   tlsCertificatePath: /etc/tls/server.crt
   tlsPrivateKeyPath: /etc/tls/server-key.pem
   rpcAclsPath: /etc/rpcacls/rpcacls.json
+  enableGracefulShutdown: true
 }

--- a/common/server/framework/src/main/resources/reference.conf
+++ b/common/server/framework/src/main/resources/reference.conf
@@ -62,4 +62,5 @@ server {
   disableSslAuthorization: false
   ipFilterRules: []
   ipFilterInternalOnly: false
+  enableGracefulShutdown: false
 }

--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.105
+version = 0.0.106

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/tasks/DeployPodTask.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/tasks/DeployPodTask.java
@@ -287,7 +287,11 @@ public class DeployPodTask extends DefaultTask {
             .build();
     Map<String, Service> additionalServices = new HashMap<>();
     for (String path : deploymentConfig.additionalServicePaths()) {
-      String serviceName = deploymentConfig.deploymentName() + path.replace('/', '-');
+      String sanitizedPath = path;
+      if (sanitizedPath.endsWith("/*")) {
+        sanitizedPath = sanitizedPath.substring(0, path.length() - 2);
+      }
+      String serviceName = deploymentConfig.deploymentName() + sanitizedPath.replace('/', '-');
       additionalServices.put(
           path,
           new ServiceBuilder()

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -311,7 +311,7 @@ class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.curioswitch.curiostack")
-              .version("0.0.51")
+              .version("0.0.54")
               .addModules("curio-server-framework")
               .build(),
           ImmutableDependencySet.builder()


### PR DESCRIPTION
redis cluster IP.