### PR TITLE
Tweak JVM settings

### DIFF
--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.113
+version = 0.0.114

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/tasks/DeployPodTask.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/tasks/DeployPodTask.java
@@ -126,16 +126,20 @@ public class DeployPodTask extends DefaultTask {
                                         .build()))
                     ::iterator);
     if (!deploymentConfig.envVars().containsKey("JAVA_OPTS")) {
-      int numWorkers = (int) (Math.ceil(Double.parseDouble(deploymentConfig.cpu())) * 2);
-      int heapSize = (int) (deploymentConfig.memoryMb() * 0.6);
+      int numCpus = (int) Math.ceil(Double.parseDouble(deploymentConfig.cpu()));
+      int numWorkers = numCpus * 2;
+      int heapSize = (int) (deploymentConfig.memoryMb() * 0.5);
       StringBuilder javaOpts = new StringBuilder();
       javaOpts
-          .append("-Xms")
+          .append("-XX:+PrintFlagsFinal -Xms")
           .append(heapSize)
           .append("m ")
           .append("-Xmx")
           .append(heapSize)
           .append("m ")
+          .append("-XX:ParallelGCThreads=")
+          .append(numCpus)
+          .append(" ")
           .append("-Dconfig.resource=application-")
           .append(type)
           .append(".conf ")
@@ -147,6 +151,9 @@ public class DeployPodTask extends DefaultTask {
           .append(" ")
           .append("-Dcom.linecorp.armeria.numCommonWorkers=")
           .append(numWorkers)
+          .append(" ")
+          .append("-Dio.netty.availableProcessors=")
+          .append(numCpus)
           .append(" ");
       if (!type.equals("prod")) {
         javaOpts.append("-Dcom.linecorp.armeria.verboseExceptions=true ");

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
@@ -233,15 +233,20 @@ public class GcloudPlugin implements Plugin<Project> {
                             proj.getConvention()
                                 .getPlugin(BasePluginConvention.class)
                                 .getArchivesBaseName();
-                        String buildImageId = "curio-generated-build-" + archivesBaseName + "-image";
-                        String tagRevisionId = "curio-generated-tag-" + archivesBaseName + "-image";
-                        String pushLatestTagId = "curio-generated-push-" + archivesBaseName + "-latest";
-                        String pushRevisionTagId = "curio-generated-push-" + archivesBaseName + "-revision";
+                        String buildImageId =
+                            "curio-generated-build-" + archivesBaseName + "-image";
+                        String pushLatestTagId =
+                            "curio-generated-push-" + archivesBaseName + "-latest";
+                        String pushRevisionTagId =
+                            "curio-generated-push-" + archivesBaseName + "-revision";
                         String deployId = "curio-generated-deploy-" + archivesBaseName;
                         String latestTag =
                             config.containerRegistry() + "/$PROJECT_ID/" + archivesBaseName;
                         String revisionTag =
-                            config.containerRegistry() + "/$PROJECT_ID/" + archivesBaseName + ":$REVISION_ID";
+                            config.containerRegistry()
+                                + "/$PROJECT_ID/"
+                                + archivesBaseName
+                                + ":$REVISION_ID";
                         String dockerPath =
                             Paths.get(rootProject.getProjectDir().getAbsolutePath())
                                 .relativize(
@@ -267,25 +272,10 @@ public class GcloudPlugin implements Plugin<Project> {
                                             + dockerPath
                                             + " && docker build --tag="
                                             + latestTag
-                                            + " "
-                                            + dockerPath
-                                            + " || echo Skipping..."))
-                                .build());
-                        steps.add(
-                            ImmutableCloudBuildStep.builder()
-                                .id(tagRevisionId)
-                                .addWaitFor(buildImageId)
-                                .name(dockerBuilder)
-                                .entrypoint("/bin/bash")
-                                .args(
-                                    ImmutableList.of(
-                                        "-c",
-                                        "test -e "
-                                            + dockerPath
-                                            + " && docker tag "
-                                            + latestTag
-                                            + " "
+                                            + " --tag="
                                             + revisionTag
+                                            + " "
+                                            + dockerPath
                                             + " || echo Skipping..."))
                                 .build());
                         steps.add(
@@ -306,7 +296,7 @@ public class GcloudPlugin implements Plugin<Project> {
                         steps.add(
                             ImmutableCloudBuildStep.builder()
                                 .id(pushRevisionTagId)
-                                .addWaitFor(tagRevisionId)
+                                .addWaitFor(buildImageId)
                                 .name(dockerBuilder)
                                 .entrypoint("/bin/bash")
                                 .args(


### PR DESCRIPTION
Set netty available processors / GC threads based on deployment CPU and print flags on startup.

Also allow cloudbuild to push revision-id tags of docker images.