### PR TITLE
Fix proto generation on windows and improve devenv setup.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'org.curioswitch.curiostack:gradle-curiostack-plugin:0.0.104'
+        classpath 'org.curioswitch.curiostack:gradle-curiostack-plugin:0.0.115'
     }
 }
 

--- a/common/server/framework/gradle.properties
+++ b/common/server/framework/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.56
+version = 0.0.57

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/database/DatabaseModule.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/database/DatabaseModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * MIT License
  *
  * Copyright (c) 2018 Choko (choko@curioswitch.org)
@@ -75,10 +75,19 @@ public abstract class DatabaseModule {
     hikari.setJdbcUrl(config.getJdbcUrl());
     hikari.setUsername(config.getUsername());
     hikari.setPassword(config.getPassword());
-    hikari.addDataSourceProperty("cachePrepStmts", "true");
+    hikari.addDataSourceProperty("cachePrepStmts", true);
+    hikari.addDataSourceProperty("prepStmtCacheSize", 250);
+    hikari.addDataSourceProperty("prepStmtCacheSqlLimit", 2048);
+    hikari.addDataSourceProperty("useServerPrepStmts", true);
+    hikari.addDataSourceProperty("useLocalSessionState", true);
+    hikari.addDataSourceProperty("useLocalTransactionState", true);
+    hikari.addDataSourceProperty("rewriteBatchedStatements", true);
+    hikari.addDataSourceProperty("cacheResultSetMetadata", true);
+    hikari.addDataSourceProperty("cacheServerConfiguration", true);
+    hikari.addDataSourceProperty("elideSetAutoCommits", true);
+    hikari.addDataSourceProperty("maintainTimeStats", false);
     hikari.addDataSourceProperty(
         "statementInterceptors", "brave.mysql.TracingStatementInterceptor");
-    hikari.addDataSourceProperty("useUnicode", "yes");
     hikari.setMetricsTrackerFactory(new PrometheusMetricsTrackerFactory());
     return new HikariDataSource(hikari);
   }

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,7 +37,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'org.curioswitch.curiostack:gradle-curiostack-plugin:0.0.104'
+        classpath 'org.curioswitch.curiostack:gradle-curiostack-plugin:0.0.115'
     }
 }
 

--- a/tools/gradle-plugins/gradle-curiostack-plugin/build.gradle
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     compile 'com.palantir:gradle-baseline-java'
     compile 'gradle.plugin.com.boxfuse.client:flyway-release'
     compile 'gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties'
+    compile 'gradle.plugin.com.jetbrains.python:gradle-python-envs'
     compile 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin'
     compile 'io.fabric8:kubernetes-client'
     compile 'io.spring.gradle:dependency-management-plugin'

--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.114
+version = 0.0.115

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -373,6 +373,7 @@ class StandardDependencies {
           "com.palantir:gradle-baseline-java:0.10.0",
           "gradle.plugin.com.boxfuse.client:flyway-release:5.0.2",
           "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.4.17",
+          "gradle.plugin.com.jetbrains.python:gradle-python-envs:0.0.25",
           "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0",
           "io.spring.gradle:dependency-management-plugin:1.0.4.RELEASE",
           "javax.activation:activation:1.1.1",

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -311,7 +311,7 @@ class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.curioswitch.curiostack")
-              .version("0.0.56")
+              .version("0.0.57")
               .addModules("curio-server-framework")
               .build(),
           ImmutableDependencySet.builder()

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/tasks/CreateShellConfigTask.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/tasks/CreateShellConfigTask.java
@@ -1,0 +1,90 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.plugins.curiostack.tasks;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.diffplug.common.io.Files;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.tools.ant.taskdefs.condition.Os;
+import org.curioswitch.gradle.plugins.shared.CommandUtil;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+public class CreateShellConfigTask extends DefaultTask {
+
+  List<Path> paths = ImmutableList.of();
+
+  public CreateShellConfigTask path(Path path) {
+    paths = ImmutableList.<Path>builder().addAll(paths).add(path).build();
+    return this;
+  }
+
+  @Input
+  public List<String> getPaths() {
+    return paths.stream().map(Path::toAbsolutePath).map(Path::toString).collect(toImmutableList());
+  }
+
+  @OutputFile
+  public Path getConfigPath() {
+    return CommandUtil.getCuriostackDir(getProject()).resolve("curiostack_config");
+  }
+
+  @TaskAction
+  public void exec() {
+    String joined =
+        getPaths()
+            .stream()
+            .map(
+                path -> {
+                  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    // Assume msys or cygwin for now.
+                    return "/"
+                        + path.substring(0, 1).toLowerCase()
+                        + "/"
+                        + path.substring("C:\\".length()).replace('\\', '/');
+                  } else {
+                    return path;
+                  }
+                })
+            .collect(Collectors.joining(":"));
+    try {
+      Files.write(
+          "export PATH=" + joined + ":$PATH\n" + "export CLOUDSDK_PYTHON_SITEPACKAGES=1",
+          getConfigPath().toFile(),
+          StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Could not write config.", e);
+    }
+  }
+}

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
@@ -191,6 +191,28 @@ public class GcloudPlugin implements Plugin<Project> {
                   config.clusterZone()));
 
           project.getTasks().create("createBuildCacheBucket", CreateBuildCacheBucket.class);
+
+          GcloudTask installBetaComponents =
+              project
+                  .getTasks()
+                  .create(
+                      "gcloudInstallBetaComponents",
+                      GcloudTask.class,
+                      t -> t.setArgs(ImmutableList.of("components", "install", "beta")));
+          installBetaComponents.dependsOn(setupTask);
+          GcloudTask installKubectl =
+              project
+                  .getTasks()
+                  .create(
+                      "gcloudInstallKubectl",
+                      GcloudTask.class,
+                      t -> t.setArgs(ImmutableList.of("components", "install", "kubectl")));
+          installKubectl.dependsOn(setupTask);
+          project
+              .getTasks()
+              .create(
+                  "gcloudSetup",
+                  t -> t.dependsOn(setupTask, installBetaComponents, installKubectl));
         });
 
     addGenerateCloudBuildTask(project);

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
@@ -107,10 +107,10 @@ public class GcloudPlugin implements Plugin<Project> {
 
     project.afterEvaluate(
         p -> {
-          SetupTask setupTask = project.getTasks().create(SetupTask.NAME, SetupTask.class);
+          SetupTask downloadSdkTask = project.getTasks().create(SetupTask.NAME, SetupTask.class);
           ImmutableGcloudExtension config =
               project.getExtensions().getByType(GcloudExtension.class);
-          setupTask.setEnabled(config.download());
+          downloadSdkTask.setEnabled(config.download());
 
           project.allprojects(
               proj -> {
@@ -199,7 +199,7 @@ public class GcloudPlugin implements Plugin<Project> {
                       "gcloudInstallBetaComponents",
                       GcloudTask.class,
                       t -> t.setArgs(ImmutableList.of("components", "install", "beta")));
-          installBetaComponents.dependsOn(setupTask);
+          installBetaComponents.dependsOn(downloadSdkTask);
           GcloudTask installKubectl =
               project
                   .getTasks()
@@ -207,12 +207,12 @@ public class GcloudPlugin implements Plugin<Project> {
                       "gcloudInstallKubectl",
                       GcloudTask.class,
                       t -> t.setArgs(ImmutableList.of("components", "install", "kubectl")));
-          installKubectl.dependsOn(setupTask);
+          installKubectl.dependsOn(downloadSdkTask);
           project
               .getTasks()
               .create(
                   "gcloudSetup",
-                  t -> t.dependsOn(setupTask, installBetaComponents, installKubectl));
+                  t -> t.dependsOn(downloadSdkTask, installBetaComponents, installKubectl));
         });
 
     addGenerateCloudBuildTask(project);

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/ImmutableGcloudExtension.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/ImmutableGcloudExtension.java
@@ -107,7 +107,7 @@ public interface ImmutableGcloudExtension {
   }
 
   default String version() {
-    return "183.0.0";
+    return "189.0.0";
   }
 
   default String distBaseUrl() {

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/PlatformConfig.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/PlatformConfig.java
@@ -25,6 +25,7 @@
 package org.curioswitch.gradle.plugins.gcloud;
 
 import java.io.File;
+import org.apache.tools.ant.taskdefs.condition.Os;
 import org.curioswitch.gradle.plugins.gcloud.util.PlatformHelper;
 import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
@@ -43,10 +44,6 @@ public interface PlatformConfig {
   static PlatformConfig fromExtension(ImmutableGcloudExtension config) {
     PlatformHelper platformHelper = new PlatformHelper();
 
-    if (platformHelper.isWindows()) {
-      config.gradleProject().getLogger().info("GCloud not supported on windows yet, skipping...");
-    }
-
     String osName = platformHelper.getOsName();
     String osArch = platformHelper.getOsArch();
 
@@ -58,7 +55,8 @@ public interface PlatformConfig {
                 + osName
                 + "-"
                 + osArch
-                + "@tar.gz")
+                + "@"
+                + (Os.isFamily(Os.FAMILY_WINDOWS) ? "zip" : "tar.gz"))
         .sdkDir(
             new File(config.workDir(), "gcloud-" + config.version() + "-" + osName + "-" + osArch))
         .gcloudExec("gcloud")

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/tasks/SetupTask.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/tasks/SetupTask.java
@@ -62,6 +62,8 @@ public class SetupTask extends DefaultTask {
     platformConfig = config.platformConfig();
     repositoriesBackup = new ArrayList<>(getProject().getRepositories());
 
+    dependsOn("pythonSetup");
+
     onlyIf(
         unused -> {
           Path sdkDir = CommandUtil.getGcloudSdkDir(getProject());

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/util/PlatformHelper.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/util/PlatformHelper.java
@@ -25,7 +25,7 @@
 package org.curioswitch.gradle.plugins.gcloud.util;
 
 import java.util.Properties;
-import org.codehaus.plexus.util.Os;
+import org.apache.tools.ant.taskdefs.condition.Os;
 
 public class PlatformHelper {
 

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/util/PlatformHelper.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/util/PlatformHelper.java
@@ -25,6 +25,7 @@
 package org.curioswitch.gradle.plugins.gcloud.util;
 
 import java.util.Properties;
+import org.codehaus.plexus.util.Os;
 
 public class PlatformHelper {
 
@@ -39,18 +40,16 @@ public class PlatformHelper {
   }
 
   public String getOsName() {
-    final String name = props.getProperty("os.name").toLowerCase();
-    if (name.contains("windows")) {
-      return "win";
-    }
-    if (name.contains("mac")) {
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+      return "windows";
+    } else if (Os.isFamily(Os.FAMILY_MAC)) {
       return "darwin";
-    }
-    if (name.contains("linux")) {
+    } else if (Os.isFamily(Os.FAMILY_UNIX)) {
+      // Assume linux version works on any unix until told otherwise.
       return "linux";
     }
 
-    throw new IllegalArgumentException("Unsupported OS: " + name);
+    throw new IllegalArgumentException("Unsupported OS.");
   }
 
   public String getOsArch() {
@@ -59,9 +58,5 @@ public class PlatformHelper {
       return "x86_64";
     }
     return "x86";
-  }
-
-  public boolean isWindows() {
-    return getOsName().equals("win");
   }
 }

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/shared/CommandUtil.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/shared/CommandUtil.java
@@ -25,6 +25,7 @@
 package org.curioswitch.gradle.plugins.shared;
 
 import java.nio.file.Path;
+import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.Project;
 
 public final class CommandUtil {
@@ -34,7 +35,8 @@ public final class CommandUtil {
   }
 
   public static Path getPythonBinDir(Project project, String envName) {
-    return getPythonDir(project).resolve("envs/" + envName + "/Scripts");
+    String binDir = Os.isFamily(Os.FAMILY_WINDOWS) ? "Scripts" : "bin";
+    return getPythonDir(project).resolve("envs/" + envName + "/" + binDir);
   }
 
   public static Path getPythonExecutable(Project project, String envName) {

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/shared/CommandUtil.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/shared/CommandUtil.java
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.plugins.shared;
+
+import java.nio.file.Path;
+import org.gradle.api.Project;
+
+public final class CommandUtil {
+
+  public static Path getPythonDir(Project project) {
+    return getCuriostackDir(project).resolve("python");
+  }
+
+  public static Path getPythonBinDir(Project project, String envName) {
+    return getPythonDir(project).resolve("envs/" + envName + "/Scripts");
+  }
+
+  public static Path getPythonExecutable(Project project, String envName) {
+    return getPythonBinDir(project, envName).resolve("python");
+  }
+
+  public static Path getGcloudDir(Project project) {
+    return getCuriostackDir(project).resolve("gcloud");
+  }
+
+  public static Path getGcloudSdkDir(Project project) {
+    return getGcloudDir(project).resolve("google-cloud-sdk");
+  }
+
+  public static Path getGcloudSdkBinDir(Project project) {
+    return getGcloudSdkDir(project).resolve("bin");
+  }
+
+  public static Path getNodeDir(Project project) {
+    return getCuriostackDir(project).resolve("nodejs");
+  }
+
+  public static Path getNpmDir(Project project) {
+    return getNodeDir(project).resolve("npm");
+  }
+
+  public static Path getYarnDir(Project project) {
+    return getNodeDir(project).resolve("yarn");
+  }
+
+  public static Path getCuriostackDir(Project project) {
+    return project.getGradle().getGradleUserHomeDir().toPath().resolve("curiostack");
+  }
+
+  private CommandUtil() {}
+}


### PR DESCRIPTION
- Python is automatically setup
- All SDKs (gcloud, python, node, etc) are installed into home directory instead of project directory
- `rehash` task creates a shell script suitable for sourcing from a `.bashrc` to allow using downloaded tools. No need to install tools.