### PR TITLE
Explicitly set byte-buddy class loading strategy to pre-JDK11 default.

### DIFF
--- a/common/grpc/protobuf-jackson/gradle.properties
+++ b/common/grpc/protobuf-jackson/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.1.1
+version = 0.2.1

--- a/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/TypeSpecificMarshaller.java
+++ b/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/TypeSpecificMarshaller.java
@@ -49,6 +49,7 @@ import net.bytebuddy.asm.AsmVisitorWrapper.ForDeclaredMethods;
 import net.bytebuddy.description.type.TypeDefinition;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.jar.asm.ClassWriter;
 
 /**
@@ -265,7 +266,9 @@ abstract class TypeSpecificMarshaller<T extends Message> {
       marshaller =
           buddy
               .make()
-              .load(TypeSpecificMarshaller.class.getClassLoader())
+              .load(
+                  TypeSpecificMarshaller.class.getClassLoader(),
+                  ClassLoadingStrategy.Default.INJECTION)
               .getLoaded()
               .getConstructor(prototype.getClass())
               .newInstance(prototype);


### PR DESCRIPTION
Byte buddy 1.8.4 changed the default classload strategy to support JDK11, which loses `sun.misc.Unsafe` support. For now, explicitly enable the old strategy before making larger changes to support JDK11 with the non-unsafe loading strategy.