### PR TITLE
Publish curio 160

### DIFF
--- a/common/server/framework/gradle.properties
+++ b/common/server/framework/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.88
+version = 0.0.89

--- a/common/server/framework/src/main/resources/application.conf
+++ b/common/server/framework/src/main/resources/application.conf
@@ -25,6 +25,7 @@
 server {
   disableClientCertificateVerification: true
   generateSelfSignedCertificate: true
+  disableSslAuthorization: true
 }
 
 redis.noop: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-org.curioswitch.curiostack.version = 0.0.160-RC8
+org.curioswitch.curiostack.version = 0.0.160
 
 org.gradle.caching = true
 org.gradle.configureondemand = true

--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.160-RC8
+version = 0.0.160

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/CurioServerPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/CurioServerPlugin.java
@@ -88,9 +88,7 @@ public class CurioServerPlugin implements Plugin<Project> {
             .create(
                 "jibBuildRelease",
                 BuildImageTask.class,
-                t -> {
-                  t.getAsDynamicObject().setProperty("jibExtension", jib);
-                });
+                t -> t.getAsDynamicObject().setProperty("jibExtension", jib));
 
     var patchAlpha = project.getTasks().create("patchAlpha", KubectlTask.class);
 
@@ -158,7 +156,7 @@ public class CurioServerPlugin implements Plugin<Project> {
           jib.to(to -> to.setImage(image));
           jib.container(
               container -> {
-                container.setFormat(ImageFormat.OCI);
+                container.setFormat(ImageFormat.Docker);
                 container.setMainClass(appPluginConvention.getMainClassName());
                 container.setPorts(ImmutableList.of("8080"));
               });
@@ -205,10 +203,10 @@ public class CurioServerPlugin implements Plugin<Project> {
                     "patch",
                     "deployment/" + alpha.deploymentName(),
                     "-p",
-                    "'{\"spec\": "
+                    "{\"spec\": "
                         + "{\"template\": {\"metadata\": {\"labels\": {\"revision\": \""
                         + revisionId
-                        + "\" }}}}}'"));
+                        + "\" }}}}}"));
             patchAlpha.setIgnoreExitValue(true);
           }
 
@@ -216,8 +214,6 @@ public class CurioServerPlugin implements Plugin<Project> {
           DockerJavaApplication javaApplication =
               (DockerJavaApplication) docker.getProperty("javaApplication");
           javaApplication.setBaseImage("openjdk:10-jre-slim");
-
-          project.getTasks().getByName("build").dependsOn("dockerDistTar");
 
           for (ImmutableDeploymentConfiguration type : config.getTypes()) {
             String capitalized =

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/tasks/DeployPodTask.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/tasks/DeployPodTask.java
@@ -188,7 +188,8 @@ public class DeployPodTask extends DefaultTask {
             .collect(toImmutableList());
 
     String jvmOpts =
-        deploymentConfig.extraJvmArgs() + " " + createDefaultJvmOptions(gcloud, deploymentConfig);
+        (deploymentConfig.extraJvmArgs() + " " + createDefaultJvmOptions(gcloud, deploymentConfig))
+            .trim();
     if (!deploymentConfig.envVars().containsKey("JAVA_TOOL_OPTIONS")) {
       envVars.add(new EnvVar("JAVA_TOOL_OPTIONS", jvmOpts, null));
     }
@@ -417,8 +418,8 @@ public class DeployPodTask extends DefaultTask {
     int heapSize = deploymentConfig.jvmHeapMb();
     StringBuilder javaOpts = new StringBuilder();
     javaOpts
-        .append("--add-opens java.base/jdk.internal.misc=ALL-UNNAMED ")
-        .append("--add-opens jdk.unsupported/sun.misc=ALL-UNNAMED ")
+        .append("--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED ")
+        .append("--add-opens=jdk.unsupported/sun.misc=ALL-UNNAMED ")
         .append("-Xms")
         .append(heapSize)
         .append("m ")

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -403,7 +403,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.curioswitch.curiostack")
-              .version("0.0.88")
+              .version("0.0.89")
               .addModules("curio-server-framework")
               .build(),
           ImmutableDependencySet.builder()

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
@@ -160,7 +160,7 @@ public class GcloudPlugin implements Plugin<Project> {
                   config.clusterName(),
                   System.getenv("CLOUDSDK_COMPUTE_ZONE") != null
                       ? "--zone=" + System.getenv("CLOUDSDK_COMPUTE_ZONE")
-                      : "--region=" + config.cloudRegion()));
+                      : "--region=" + config.clusterRegion()));
 
           GcloudTask installComponents =
               project


### PR DESCRIPTION
- Docker image building / pushing done with `jib`
- `deploy` now sets JAVA_TOOL_OPTIONS instead of JAVA_OPTS so it is compatible with both gradle-docker-plugin and jib
- `patchAlpha` task added to patch an alpha deployment from Gradle
- continousTest / continuousCheck tasks removed since they're confusing, just use continuousBuild
- Cloudbuild tasks now all managed by gradle since no more docker daemon involvement
- Release build configuration
- gcloudLoginToCluster fixed to support both zone and regional clusters
- local servers `disableSslAuthorization` by default