### PR TITLE
Curio 166

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ See gradle-curiostack-plugin [README](tools/gradle-plugins/gradle-curiostack-plu
 
 ## Developing
 
-Curiostack requires JDK10.
+Curiostack requires JDK8 and JDK11.
 
 ```bash
-$ sudo add-apt-repository ppa:linuxuprising/java
+$ sudo add-apt-repository ppa:openjdk-r/ppa
 $ sudo apt-get update
-$ sudo apt-get install oracle-java9-installer
+$ sudo apt-get install openjdk-8-jdk-headless
+$ sudo apt-get install openjdk-11-jdk-headless
+$ sudo  update-java-alternatives --set java-1.11.0-openjdk-amd64
 ```
 
 First run

--- a/auth/server/build.gradle
+++ b/auth/server/build.gradle
@@ -42,9 +42,3 @@ deployment {
         }
     }
 }
-
-docker {
-    javaApplication {
-        maintainer = 'Choko (choko@curioswitch.org)'
-    }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ plugins {
 allprojects {
     project.group = 'org.curioswitch.curiostack'
 
+    tasks.withType(org.gradle.plugin.devel.tasks.ValidateTaskProperties) {
+        // Disable this until Gradle 5 fixes Java 11 compatability.
+        enabled = false
+    }
+
     plugins.withType(org.gradle.api.publish.maven.plugins.MavenPublishPlugin) {
         project.apply plugin: 'com.jfrog.bintray'
         // This should happen automatically, not clear why not.

--- a/cloudbuild-release.yaml
+++ b/cloudbuild-release.yaml
@@ -24,7 +24,7 @@ steps:
   waitFor:
   - curio-generated-fetch-uncompressed-build-cache
   - curio-generated-fetch-compressed-build-cache
-  name: openjdk:10-jdk-slim
+  name: openjdk:11-jdk-slim
   entrypoint: bash
   args:
   - -c

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,7 @@ steps:
 - id: curio-generated-fetch-builder-image
   waitFor:
   - '-'
-  name: openjdk:10-jdk-slim
+  name: openjdk:11-jdk-slim
   entrypoint: bash
   args:
   - -c
@@ -40,7 +40,7 @@ steps:
   waitFor:
   - curio-generated-deepen-git-repo
   - curio-generated-fetch-compressed-build-cache
-  name: openjdk:10-jdk-slim
+  name: openjdk:11-jdk-slim
   volumes:
   - name: gradle-wrapper
     path: /root/.gradle/wrapper

--- a/common/google-cloud/core/src/main/java/org/curioswitch/curiostack/gcloud/core/auth/GooglePublicKeysManager.java
+++ b/common/google-cloud/core/src/main/java/org/curioswitch/curiostack/gcloud/core/auth/GooglePublicKeysManager.java
@@ -146,9 +146,10 @@ public class GooglePublicKeysManager {
                       .map(
                           valueNode -> {
                             try {
-                              return (CERTIFICATE_FACTORY.generateCertificate(
+                              return CERTIFICATE_FACTORY
+                                  .generateCertificate(
                                       new ByteArrayInputStream(
-                                          valueNode.textValue().getBytes(StandardCharsets.UTF_8))))
+                                          valueNode.textValue().getBytes(StandardCharsets.UTF_8)))
                                   .getPublicKey();
                             } catch (CertificateException e) {
                               throw new IllegalArgumentException(

--- a/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/WellKnownTypeMarshaller.java
+++ b/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/WellKnownTypeMarshaller.java
@@ -360,7 +360,7 @@ abstract class WellKnownTypeMarshaller<T extends Message> extends TypeSpecificMa
     public void doMerge(JsonParser parser, int currentDepth, Message.Builder messageBuilder)
         throws IOException {
       Struct.Builder builder = (Struct.Builder) messageBuilder;
-      while ((parser.nextValue()) != JsonToken.END_OBJECT) {
+      while (parser.nextValue() != JsonToken.END_OBJECT) {
         builder.putFields(
             parser.getCurrentName(), ValueMarshaller.INSTANCE.readValue(parser, currentDepth + 1));
       }

--- a/common/server/framework/build.gradle
+++ b/common/server/framework/build.gradle
@@ -30,10 +30,6 @@ archivesBaseName = 'curio-server-framework'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 
-// Spring dependencies plugin is not aware of classifiers. Eventually see if netflix plugins work
-// better (it is possibly a limitation of gradle itself).
-def sfmVersion = '3.18.1'
-
 dependencies {
     api project(':common:google-cloud:iam')
     api project(':common:google-cloud:trace')
@@ -51,7 +47,7 @@ dependencies {
     api 'io.zipkin.brave:brave'
     api 'org.apache.logging.log4j:log4j-api'
     api 'org.jooq:jooq'
-    api group: 'org.simpleflatmapper', name: 'sfm-jooq', classifier: 'jdk9', version: dependencyManagement.managedVersions['org.simpleflatmapper:sfm-jooq']
+    api 'org.simpleflatmapper:sfm-jooq'
 
     implementation 'com.auth0:java-jwt'
     implementation 'com.fasterxml.jackson.core:jackson-databind'
@@ -76,9 +72,6 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
     implementation 'org.bouncycastle:bcpkix-jdk15on'
     implementation 'org.jctools:jctools-core'
-    ['sfm-converter', 'sfm-jdbc', 'sfm-map', 'sfm-reflect', 'sfm-util'].each {
-        implementation group: 'org.simpleflatmapper', name: it, classifier: 'jdk9', version: dependencyManagement.managedVersions["org.simpleflatmapper:${it}"]
-    }
 
     runtime 'com.google.cloud.sql:mysql-socket-factory-connector-j-8'
     runtime 'javax.xml.bind:jaxb-api'

--- a/common/server/framework/gradle.properties
+++ b/common/server/framework/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.90
+version = 0.0.91

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/ServerModule.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/ServerModule.java
@@ -585,13 +585,13 @@ public abstract class ServerModule {
       service =
           service
               .decorate(
-                  ((delegate, ctx, req) -> {
+                  (delegate, ctx, req) -> {
                     DecodedJWT jwt = ctx.attr(JwtAuthorizer.DECODED_JWT).get();
                     String loggedInUserEmail =
                         jwt != null ? jwt.getClaim("email").asString() : "unknown";
                     RequestLoggingContext.put(ctx, "logged_in_user", loggedInUserEmail);
                     return delegate.serve(ctx, req);
-                  }))
+                  })
               .decorate(
                   new HttpAuthServiceBuilder()
                       .addTokenAuthorizer(

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/config/RedisConfig.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/config/RedisConfig.java
@@ -39,6 +39,9 @@ public interface RedisConfig {
    */
   String getUrl();
 
+  /** Whether the redis server is using redis cluster. */
+  boolean isCluster();
+
   /**
    * Whether a noop cache should be used instead of redis. Should only be enabled for local
    * development.

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/monitoring/MonitoringModule.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/monitoring/MonitoringModule.java
@@ -94,6 +94,7 @@ public abstract class MonitoringModule {
 
   @Provides
   @Singleton
+  @SuppressWarnings("CloseableProvides")
   static Tracing tracing(Lazy<StackdriverReporter> reporter, MonitoringConfig config) {
     Tracing.Builder builder =
         Tracing.newBuilder()

--- a/common/server/framework/src/main/resources/reference.conf
+++ b/common/server/framework/src/main/resources/reference.conf
@@ -92,4 +92,5 @@ server {
 redis {
   url: ""
   noop: false
+  cluster: false
 }

--- a/common/testing/assertj-protobuf/src/main/java/org/curioswitch/common/testing/assertj/proto/FieldScopeImpl.java
+++ b/common/testing/assertj-protobuf/src/main/java/org/curioswitch/common/testing/assertj/proto/FieldScopeImpl.java
@@ -53,6 +53,7 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Implementation of a {@link FieldScope}. It takes a logic component {@link FieldScopeLogic}, and
@@ -176,6 +177,7 @@ abstract class FieldScopeImpl extends FieldScope {
   //////////////////////////////////////////////////////////////////////////////////////////////////
 
   @Override
+  @Nullable
   String usingCorrespondenceString(Optional<Descriptor> descriptor) {
     return usingCorrespondenceStringFunction().apply(descriptor);
   }

--- a/common/testing/assertj-protobuf/src/main/java/org/curioswitch/common/testing/assertj/proto/FluentEqualityConfig.java
+++ b/common/testing/assertj-protobuf/src/main/java/org/curioswitch/common/testing/assertj/proto/FluentEqualityConfig.java
@@ -56,6 +56,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
+import javax.annotation.Nullable;
 import org.assertj.core.data.Offset;
 
 /**
@@ -125,6 +126,7 @@ public abstract class FluentEqualityConfig
   // For pretty-printing, does not affect behavior.
   abstract Function<? super Optional<Descriptor>, String> usingCorrespondenceStringFunction();
 
+  @Nullable
   final String usingCorrespondenceString(Optional<Descriptor> descriptor) {
     return usingCorrespondenceStringFunction().apply(descriptor);
   }

--- a/common/testing/assertj-protobuf/src/main/java/org/curioswitch/common/testing/assertj/proto/ProtoTruthMessageDifferencer.java
+++ b/common/testing/assertj-protobuf/src/main/java/org/curioswitch/common/testing/assertj/proto/ProtoTruthMessageDifferencer.java
@@ -597,7 +597,11 @@ final class ProtoTruthMessageDifferencer {
   // Requires at least one parameter is non-null.
   private static Message orDefaultForType(
       @NullableDecl Message input, @NullableDecl Message other) {
-    return (input != null) ? input : other.getDefaultInstanceForType();
+    if (input != null) {
+      return input;
+    }
+    checkNotNull(other, "One of input or other must not be null.");
+    return other.getDefaultInstanceForType();
   }
 
   private SingularField compareSingularMessage(

--- a/gateway/server/build.gradle
+++ b/gateway/server/build.gradle
@@ -40,9 +40,3 @@ dependencies {
     annotationProcessor 'org.immutables:value'
     compileOnly group: 'org.immutables', name: 'value', classifier: 'annotations'
 }
-
-docker {
-    javaApplication {
-        maintainer = 'Choko (choko@curioswitch.org)'
-    }
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-org.curioswitch.curiostack.version = 0.0.165
+org.curioswitch.curiostack.version = 0.0.166
 
 org.gradle.caching = true
 org.gradle.configureondemand = true

--- a/tools/cloudbuild-github-functions/config.yml
+++ b/tools/cloudbuild-github-functions/config.yml
@@ -55,7 +55,7 @@ repos:
           - fetch-source
           - curio-generated-fetch-uncompressed-build-cache
           - curio-generated-fetch-compressed-build-cache
-          name: openjdk:10-jdk-slim
+          name: openjdk:11-jdk-slim
           entrypoint: bash
           args:
           - -c

--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.165
+version = 0.0.166

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/CurioServerPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/CurioServerPlugin.java
@@ -24,9 +24,6 @@
 
 package org.curioswitch.gradle.plugins.curioserver;
 
-import com.bmuschko.gradle.docker.DockerExtension;
-import com.bmuschko.gradle.docker.DockerJavaApplication;
-import com.bmuschko.gradle.docker.DockerJavaApplicationPlugin;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.tools.jib.gradle.BuildImageTask;
 import com.google.cloud.tools.jib.gradle.DockerContextTask;
@@ -37,7 +34,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.gorylenko.GitPropertiesPlugin;
-import groovy.lang.GroovyObject;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -192,12 +188,6 @@ public class CurioServerPlugin implements Plugin<Project> {
                   t.setIgnoreExitValue(true);
                 });
           }
-
-          GroovyObject docker = project.getExtensions().getByType(DockerExtension.class);
-          DockerJavaApplication javaApplication =
-              (DockerJavaApplication) docker.getProperty("javaApplication");
-          javaApplication.setBaseImage("openjdk:10-jre-slim");
         });
-    project.getPluginManager().apply(DockerJavaApplicationPlugin.class);
   }
 }

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
@@ -75,6 +75,7 @@ import org.curioswitch.gradle.plugins.curiostack.StandardDependencies.Dependency
 import org.curioswitch.gradle.plugins.curiostack.tasks.CreateShellConfigTask;
 import org.curioswitch.gradle.plugins.curiostack.tasks.SetupGitHooks;
 import org.curioswitch.gradle.plugins.gcloud.GcloudPlugin;
+import org.curioswitch.gradle.plugins.nodejs.NodePlugin;
 import org.curioswitch.gradle.plugins.nodejs.util.NodeUtil;
 import org.curioswitch.gradle.tooldownloader.DownloadedToolManager;
 import org.curioswitch.gradle.tooldownloader.ToolDownloaderPlugin;
@@ -132,7 +133,7 @@ public class CuriostackPlugin implements Plugin<Project> {
     plugins.apply(CondaBuildEnvPlugin.class);
     plugins.apply(CurioGenericCiPlugin.class);
     plugins.apply(GcloudPlugin.class);
-    plugins.apply(org.curioswitch.gradle.plugins.nodejs.NodePlugin.class);
+    plugins.apply(NodePlugin.class);
     plugins.apply(ToolDownloaderPlugin.class);
 
     rootProject

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
@@ -257,6 +257,9 @@ public class CuriostackPlugin implements Plugin<Project> {
     project.getRepositories().maven(maven -> maven.setUrl("https://dl.bintray.com/mockito/maven"));
     project.getRepositories().mavenCentral();
     project.getRepositories().mavenLocal();
+    project
+        .getRepositories()
+        .maven(maven -> maven.setUrl("https://oss.sonatype.org/content/repositories/snapshots/"));
     project.getRepositories().maven(maven -> maven.setUrl("https://oss.jfrog.org/libs-snapshot"));
   }
 
@@ -317,7 +320,6 @@ public class CuriostackPlugin implements Plugin<Project> {
             .put("OptionalNotPresent", ERROR)
             .put("OverrideThrowableToString", ERROR)
             .put("PreconditionsInvalidPlaceholder", ERROR)
-            .put("ProtoFieldPreconditionsCheckNotNull", ERROR)
             .put("ShortCircuitBoolean", ERROR)
             .put("StaticGuardedByInstance", ERROR)
             .put("StreamResourceLeak", ERROR)
@@ -399,8 +401,8 @@ public class CuriostackPlugin implements Plugin<Project> {
             });
 
     JavaPluginConvention javaPlugin = project.getConvention().getPlugin(JavaPluginConvention.class);
-    javaPlugin.setSourceCompatibility(JavaVersion.VERSION_1_10);
-    javaPlugin.setTargetCompatibility(JavaVersion.VERSION_1_10);
+    javaPlugin.setSourceCompatibility(JavaVersion.VERSION_11);
+    javaPlugin.setTargetCompatibility(JavaVersion.VERSION_11);
 
     project
         .getTasks()
@@ -465,6 +467,9 @@ public class CuriostackPlugin implements Plugin<Project> {
     project
         .getDependencies()
         .add(ErrorPronePlugin.CONFIGURATION_NAME, "com.google.errorprone:error_prone_core");
+    project
+        .getDependencies()
+        .add(ErrorPronePlugin.CONFIGURATION_NAME, "com.google.auto.value:auto-value-annotations");
     project.afterEvaluate(CuriostackPlugin::addStandardJavaTestDependencies);
 
     project

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -185,7 +185,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.errorprone")
-              .version("2.3.1")
+              .version("2.3.2-SNAPSHOT")
               .addModules("error_prone_core")
               .build(),
           ImmutableDependencySet.builder()
@@ -262,12 +262,12 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("io.lettuce")
-              .version("5.0.4.RELEASE")
+              .version("5.1.0.RELEASE")
               .addModules("lettuce-core")
               .build(),
           ImmutableDependencySet.builder()
               .group("io.grpc")
-              .version("1.15.0")
+              .version("1.15.1")
               .addModules(
                   "grpc-all",
                   "grpc-auth",
@@ -404,7 +404,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.curioswitch.curiostack")
-              .version("0.0.90")
+              .version("0.0.91")
               .addModules("curio-server-framework")
               .build(),
           ImmutableDependencySet.builder()
@@ -464,7 +464,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.simpleflatmapper")
-              .version("5.0.1")
+              .version("5.0.2")
               .addModules(
                   "sfm-converter", "sfm-jdbc", "sfm-jooq", "sfm-map", "sfm-reflect", "sfm-util")
               .build(),
@@ -476,7 +476,7 @@ public class StandardDependencies {
 
   static final ImmutableList<String> DEPENDENCIES =
       ImmutableList.of(
-          "com.bmuschko:gradle-docker-plugin:3.6.1",
+          "com.bmuschko:gradle-docker-plugin:3.6.2",
           "com.diffplug.spotless:spotless-plugin-gradle:3.15.0",
           "com.github.ben-manes:gradle-versions-plugin:0.20.0",
           "com.google.protobuf:protobuf-gradle-plugin:0.8.6",

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/grpcapi/GrpcApiPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/grpcapi/GrpcApiPlugin.java
@@ -229,16 +229,15 @@ public class GrpcApiPlugin implements Plugin<Project> {
                     .create("addResolvedPluginScript")
                     .dependsOn(installTsProtocGen)
                     .doFirst(
-                        t -> {
-                          writeResolvedScript(
-                              project,
-                              DownloadedToolManager.get(project)
-                                  .getBinDir("node")
-                                  .resolve("node")
-                                  .toString(),
-                              "protoc-gen-ts-resolved",
-                              "ts-protoc-gen/lib/index");
-                        });
+                        t ->
+                            writeResolvedScript(
+                                project,
+                                DownloadedToolManager.get(project)
+                                    .getBinDir("node")
+                                    .resolve("node")
+                                    .toString(),
+                                "protoc-gen-ts-resolved",
+                                "ts-protoc-gen/lib/index"));
             addResolvedPluginScript
                 .getOutputs()
                 .files(
@@ -297,7 +296,8 @@ public class GrpcApiPlugin implements Plugin<Project> {
             SourceSetContainer sourceSets =
                 project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
             if (sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).getAllJava().isEmpty()) {
-              project.getTasks().getByName("compileTestJava").setEnabled(false);
+              project.getTasks().named("compileTestJava").configure(t -> t.setEnabled(false));
+              project.getTasks().named("test").configure(t -> t.setEnabled(false));
             }
           }
         });

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/terraform/TerraformSetupPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/terraform/TerraformSetupPlugin.java
@@ -28,7 +28,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.curioswitch.gradle.golang.GolangPlugin;
+import org.curioswitch.gradle.golang.GolangSetupPlugin;
 import org.curioswitch.gradle.golang.tasks.GoTask;
 import org.curioswitch.gradle.helpers.platform.PathUtil;
 import org.curioswitch.gradle.plugins.curiostack.StandardDependencies;
@@ -49,7 +49,7 @@ public class TerraformSetupPlugin implements Plugin<Project> {
         project.getParent() == null,
         "TerraformSetupPlugin can only be applied to the root project.");
     project.getPlugins().apply(ToolDownloaderPlugin.class);
-    project.getPlugins().apply(GolangPlugin.class);
+    project.getPlugins().apply(GolangSetupPlugin.class);
 
     project
         .getPlugins()

--- a/tools/gradle-plugins/gradle-golang-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-golang-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.10
+version = 0.0.11

--- a/tools/gradle-plugins/gradle-golang-plugin/src/main/java/org/curioswitch/gradle/golang/GolangPlugin.java
+++ b/tools/gradle-plugins/gradle-golang-plugin/src/main/java/org/curioswitch/gradle/golang/GolangPlugin.java
@@ -63,18 +63,6 @@ public class GolangPlugin implements Plugin<Project> {
 
     project.getPlugins().apply(BasePlugin.class);
 
-    project
-        .getExtensions()
-        .getByType(ExtraPropertiesExtension.class)
-        .set(
-            "gopath",
-            project
-                .getGradle()
-                .getGradleUserHomeDir()
-                .toPath()
-                .resolve("curiostack")
-                .resolve("gopath"));
-
     var golang = GolangExtension.createAndAdd(project);
 
     project
@@ -114,6 +102,18 @@ public class GolangPlugin implements Plugin<Project> {
     } catch (IOException e) {
       throw new UncheckedIOException("Could not create lock file.", e);
     }
+
+    project
+        .getExtensions()
+        .getByType(ExtraPropertiesExtension.class)
+        .set(
+            "gopath",
+            project
+                .getGradle()
+                .getGradleUserHomeDir()
+                .toPath()
+                .resolve("curiostack")
+                .resolve("gopath"));
 
     var downloadDeps =
         project

--- a/tools/gradle-plugins/gradle-golang-plugin/src/main/java/org/curioswitch/gradle/golang/GolangSetupPlugin.java
+++ b/tools/gradle-plugins/gradle-golang-plugin/src/main/java/org/curioswitch/gradle/golang/GolangSetupPlugin.java
@@ -28,6 +28,7 @@ import org.curioswitch.gradle.conda.CondaBuildEnvPlugin;
 import org.curioswitch.gradle.tooldownloader.ToolDownloaderPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 
 public class GolangSetupPlugin implements Plugin<Project> {
 
@@ -48,5 +49,17 @@ public class GolangSetupPlugin implements Plugin<Project> {
                       tool.getPathSubDirs().add("go/bin");
                       tool.getAdditionalCachedDirs().add("gopath");
                     }));
+
+    project
+        .getExtensions()
+        .getByType(ExtraPropertiesExtension.class)
+        .set(
+            "gopath",
+            project
+                .getGradle()
+                .getGradleUserHomeDir()
+                .toPath()
+                .resolve("curiostack")
+                .resolve("gopath"));
   }
 }


### PR DESCRIPTION
- Java 11
- Uses new non-classifier simpleflatmapper that works on any JDK8+
- Supports non-cluster redis
- Update dependencies