### PR TITLE
Curio 168

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-org.curioswitch.curiostack.version = 0.0.167.7
+org.curioswitch.curiostack.version = 0.0.168
 
 org.gradle.caching = true
 org.gradle.configureondemand = true

--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.167.8
+version = 0.0.168

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
@@ -270,9 +270,6 @@ public class CuriostackPlugin implements Plugin<Project> {
     project.getRepositories().maven(maven -> maven.setUrl("https://dl.bintray.com/mockito/maven"));
     project.getRepositories().mavenCentral();
     project.getRepositories().mavenLocal();
-    project
-        .getRepositories()
-        .maven(maven -> maven.setUrl("https://oss.sonatype.org/content/repositories/snapshots/"));
     project.getRepositories().maven(maven -> maven.setUrl("https://oss.jfrog.org/libs-snapshot"));
   }
 

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -147,7 +147,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.cloud")
-              .version("1.46.0")
+              .version("1.48.0")
               .addModules(
                   "google-cloud-bigquery",
                   "google-cloud-core",
@@ -185,7 +185,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.errorprone")
-              .version("2.3.2-SNAPSHOT")
+              .version("2.3.2")
               .addModules("error_prone_core")
               .build(),
           ImmutableDependencySet.builder()
@@ -211,7 +211,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.linecorp.armeria")
-              .version("0.72.0")
+              .version("0.73.0")
               .addModules("armeria", "armeria-grpc", "armeria-retrofit2", "armeria-zipkin")
               .build(),
           ImmutableDependencySet.builder()
@@ -286,7 +286,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("io.netty")
-              .version("4.1.29.Final")
+              .version("4.1.30.Final")
               .addModules(
                   "netty-buffer",
                   "netty-codec",
@@ -306,7 +306,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("io.netty")
-              .version("2.0.15.Final")
+              .version("2.0.17.Final")
               .addModules("netty-tcnative-boringssl-static")
               .build(),
           ImmutableDependencySet.builder()
@@ -322,7 +322,7 @@ public class StandardDependencies {
           ImmutableDependencySet.builder()
               .group("io.zipkin.gcp")
               .version("0.8.2")
-              .addModules("zipkin-translation-stackdriver")
+              .addModules("zipkin-propagation-stackdriver", "zipkin-translation-stackdriver")
               .build(),
           ImmutableDependencySet.builder()
               .group("javax.inject")
@@ -454,7 +454,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.mockito")
-              .version("2.22.1")
+              .version("2.23.0")
               .addModules("mockito-core", "mockito-junit-jupiter")
               .build(),
           ImmutableDependencySet.builder()
@@ -464,7 +464,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.simpleflatmapper")
-              .version("5.0.2")
+              .version("6.0.1")
               .addModules(
                   "sfm-converter", "sfm-jdbc", "sfm-jooq", "sfm-map", "sfm-reflect", "sfm-util")
               .build(),
@@ -476,7 +476,7 @@ public class StandardDependencies {
 
   static final ImmutableList<String> DEPENDENCIES =
       ImmutableList.of(
-          "com.bmuschko:gradle-docker-plugin:3.6.2",
+          "com.bmuschko:gradle-docker-plugin:3.6.4",
           "com.diffplug.spotless:spotless-plugin-gradle:3.15.0",
           "com.github.ben-manes:gradle-versions-plugin:0.20.0",
           "com.google.protobuf:protobuf-gradle-plugin:0.8.6",

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -122,7 +122,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.api.grpc")
-              .version("0.27.0")
+              .version("0.32.0")
               .addModules("grpc-google-cloud-trace-v1")
               .build(),
           ImmutableDependencySet.builder()
@@ -336,7 +336,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("net.bytebuddy")
-              .version("1.9.0")
+              .version("1.9.1")
               .addModules("byte-buddy", "byte-buddy-agent")
               .build(),
           ImmutableDependencySet.builder()
@@ -476,7 +476,7 @@ public class StandardDependencies {
 
   static final ImmutableList<String> DEPENDENCIES =
       ImmutableList.of(
-          "com.bmuschko:gradle-docker-plugin:3.6.4",
+          "com.bmuschko:gradle-docker-plugin:3.6.2",
           "com.diffplug.spotless:spotless-plugin-gradle:3.15.0",
           "com.github.ben-manes:gradle-versions-plugin:0.20.0",
           "com.google.protobuf:protobuf-gradle-plugin:0.8.6",

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/grpcapi/GrpcApiSetupPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/grpcapi/GrpcApiSetupPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.plugins.grpcapi;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class GrpcApiSetupPlugin implements Plugin<Project> {
+
+  @Override
+  public void apply(Project project) {
+    checkState(project.getParent() == null, "GrpcApiSetupPlugin must be applied to root project.");
+  }
+}

--- a/tools/gradle-plugins/gradle-protobuf-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-protobuf-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.2
+version = 0.0.3

--- a/tools/gradle-plugins/gradle-protobuf-plugin/src/main/java/org/curioswitch/gradle/protobuf/tasks/GenerateProtoTask.java
+++ b/tools/gradle-plugins/gradle-protobuf-plugin/src/main/java/org/curioswitch/gradle/protobuf/tasks/GenerateProtoTask.java
@@ -360,7 +360,16 @@ public class GenerateProtoTask extends DefaultTask {
                                 && Objects.equals(dep.getVersion(), d.getVersion());
                           });
                   checkState(files.size() == 1);
-                  return new SimpleImmutableEntry<>(artifact, Iterables.getOnlyElement(files));
+
+                  File file = Iterables.getOnlyElement(files);
+                  if (!file.canExecute()) {
+                    if (!file.setExecutable(true)) {
+                      throw new IllegalStateException(
+                          "Could not set proto tool to executable: " + file.getAbsolutePath());
+                    }
+                  }
+
+                  return new SimpleImmutableEntry<>(artifact, file);
                 })
             .collect(toImmutableMap(Entry::getKey, Entry::getValue));
 


### PR DESCRIPTION
- Fix protoc, etc not set to executable
- Install ts-protoc-gen globally instead of for each grpc-web project
- Update dependencies