### PR TITLE
Curio 169

### DIFF
--- a/common/server/framework/build.gradle
+++ b/common/server/framework/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation 'io.grpc:grpc-services'
     implementation 'io.prometheus:simpleclient_hotspot'
     implementation 'io.prometheus:simpleclient_log4j2'
+    implementation 'io.zipkin.gcp:brave-propagation-stackdriver'
     implementation 'io.zipkin.gcp:zipkin-translation-stackdriver'
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-jcl'

--- a/common/server/framework/build.gradle
+++ b/common/server/framework/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'io.grpc:grpc-services'
     implementation 'io.prometheus:simpleclient_hotspot'
     implementation 'io.prometheus:simpleclient_log4j2'
-    implementation 'io.zipkin.gcp:brave-propagation-stackdriver'
+    implementation 'io.zipkin.gcp:brave-propagation-stackdriver:0.8.3'
     implementation 'io.zipkin.gcp:zipkin-translation-stackdriver'
     implementation 'org.apache.logging.log4j:log4j-core'
     implementation 'org.apache.logging.log4j:log4j-jcl'

--- a/common/server/framework/gradle.properties
+++ b/common/server/framework/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.92
+version = 0.0.93

--- a/common/server/framework/gradle.properties
+++ b/common/server/framework/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.93
+version = 0.0.94

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/config/DatabaseConfig.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/config/DatabaseConfig.java
@@ -51,4 +51,10 @@ public interface DatabaseConfig {
 
   /** Whether to log all queries to INFO level. */
   boolean getLogQueries();
+
+  /**
+   * The max lifetime for database connections. Should be less than the wait_timeout setting in the
+   * DB itself.
+   */
+  Duration getConnectionMaxLifetime();
 }

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/files/FileWatcher.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/files/FileWatcher.java
@@ -128,27 +128,13 @@ public class FileWatcher implements AutoCloseable {
               })
           .forEach(
               path -> {
-                final Path resolved;
-                try {
-                  resolved = watchedDirs.get(key).resolve(path).toRealPath();
-                } catch (IOException e) {
-                  logger.warn("Unexpected exception resolving path: {}", path, e);
-                  return;
-                }
+                final Path resolved = watchedDirs.get(key).resolve(path);
                 Optional<Consumer<Path>> callback =
                     registeredPaths
                         .entrySet()
                         .stream()
                         .filter(
-                            e -> {
-                              try {
-                                return e.getKey().toRealPath().equals(resolved);
-                              } catch (IOException ex) {
-                                logger.warn(
-                                    "Unexpected exception resolving path: {}", e.getKey(), ex);
-                                return false;
-                              }
-                            })
+                            e -> e.getKey().equals(resolved))
                         .map(Entry::getValue)
                         .findFirst();
                 if (callback.isPresent()) {

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/files/FileWatcher.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/files/FileWatcher.java
@@ -133,8 +133,7 @@ public class FileWatcher implements AutoCloseable {
                     registeredPaths
                         .entrySet()
                         .stream()
-                        .filter(
-                            e -> e.getKey().equals(resolved))
+                        .filter(e -> e.getKey().equals(resolved))
                         .map(Entry::getValue)
                         .findFirst();
                 if (callback.isPresent()) {

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/inject/CloseOnStop.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/inject/CloseOnStop.java
@@ -21,28 +21,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+package org.curioswitch.common.server.framework.inject;
 
-package org.curioswitch.common.server.framework.config;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
 
-import org.curioswitch.common.server.framework.immutables.JavaBeanStyle;
-import org.immutables.value.Value.Immutable;
-import org.immutables.value.Value.Modifiable;
-
-/** Configuration related to logging. */
-@Immutable
-@Modifiable
-@JavaBeanStyle
-public interface LoggingConfig {
-
-  /**
-   * Whether to do fine-grained logging of individual producer function execution. This creates a
-   * lot of output and generally should only be enabled when debugging a specific issue.
-   */
-  boolean getLogProducerExecution();
-
-  /**
-   * Whether to do fine-grained tracing of individual producer function execution. This can cause
-   * significant overhead and should be used with care.
-   */
-  boolean getTraceProducerExecution();
-}
+/**
+ * {@link Qualifier} to use on {@link Object} type providers to indicate the provided objects should
+ * be closed after server shutdown.
+ *
+ * <p>For example,
+ *
+ * <pre>{@code
+ * {@literal @}Module
+ * public class MyModule {
+ *   {@literal @}Provides
+ *   {@literal @}Singleton
+ *   public Database database() {
+ *     return Database.connect();
+ *   }
+ *
+ *   {@literal @Provides}
+ *   {@literal @ElementsIntoSet}
+ *   {@literal @CloseOnStop}
+ *   public Set<Closeable> init(Database database) {
+ *     return ImmutableSet.of(database);
+ *   }
+ * }
+ * }</pre>
+ */
+@Qualifier
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
+public @interface CloseOnStop {}

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/logging/LoggingModule.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/logging/LoggingModule.java
@@ -44,7 +44,6 @@ public abstract class LoggingModule {
   @Provides
   @Singleton
   static LoggingConfig config(Config config) {
-    System.out.println("foo");
     return ConfigBeanFactory.create(config.getConfig("logging"), ModifiableLoggingConfig.class)
         .toImmutable();
   }

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/logging/TracingProductionComponentMonitor.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/logging/TracingProductionComponentMonitor.java
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.common.server.framework.logging;
+
+import brave.Span;
+import brave.Tracer;
+import brave.Tracing;
+import dagger.producers.monitoring.ProducerMonitor;
+import dagger.producers.monitoring.ProducerToken;
+import dagger.producers.monitoring.ProductionComponentMonitor;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+class TracingProductionComponentMonitor extends ProductionComponentMonitor {
+
+  static class Factory extends ProductionComponentMonitor.Factory {
+
+    private final Tracing tracing;
+
+    @Inject
+    Factory(Tracing tracing) {
+      this.tracing = tracing;
+    }
+
+    @Override
+    public ProductionComponentMonitor create(Object component) {
+      return new TracingProductionComponentMonitor(
+          component.getClass().getSimpleName(), tracing.tracer());
+    }
+  }
+
+  private final String componentName;
+  private final Tracer tracer;
+
+  TracingProductionComponentMonitor(String componentName, Tracer tracer) {
+    this.componentName = componentName;
+    this.tracer = tracer;
+  }
+
+  @Override
+  public ProducerMonitor producerMonitorFor(ProducerToken token) {
+    return new TracingProducerMonitor(componentName + "." + token.toString());
+  }
+
+  private class TracingProducerMonitor extends ProducerMonitor {
+
+    private final String name;
+
+    @Nullable private Span span;
+
+    private TracingProducerMonitor(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public void methodStarting() {
+      if (tracer.currentSpan() == null) {
+        return;
+      }
+      span = tracer.nextSpan().name(name).start();
+    }
+
+    @Override
+    public void succeeded(Object value) {
+      if (span != null) {
+        span.tag("success", "true");
+        span.finish();
+      }
+    }
+
+    @Override
+    public void failed(Throwable t) {
+      if (span != null) {
+        span.tag("success", "false");
+        span.finish();
+      }
+    }
+  }
+}

--- a/common/server/framework/src/main/resources/reference.conf
+++ b/common/server/framework/src/main/resources/reference.conf
@@ -51,6 +51,7 @@ javascriptConfig {
 
 logging {
   logProducerExecution: false
+  traceProducerExecution: false
 }
 
 monitoring {

--- a/common/server/framework/src/main/resources/reference.conf
+++ b/common/server/framework/src/main/resources/reference.conf
@@ -28,6 +28,7 @@ database {
   password: ""
   leakDetectionThreshold: 0
   logQueries: false
+  connectionMaxLifetime: 28000s
 }
 
 firebaseAuth {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-org.curioswitch.curiostack.version = 0.0.168
+org.curioswitch.curiostack.version = 0.0.169
 
 org.gradle.caching = true
 org.gradle.configureondemand = true

--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.168
+version = 0.0.169

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/CurioServerSetupPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/CurioServerSetupPlugin.java
@@ -1,0 +1,73 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.plugins.curioserver;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import org.curioswitch.gradle.helpers.platform.PlatformHelper;
+import org.curioswitch.gradle.tooldownloader.ToolDownloaderPlugin;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class CurioServerSetupPlugin implements Plugin<Project> {
+
+  @Override
+  public void apply(Project project) {
+    checkState(
+        project.getParent() == null, "CurioServerSetupPlugin can only be applied to base project.");
+
+    project.getPlugins().apply(ToolDownloaderPlugin.class);
+
+    project
+        .getPlugins()
+        .withType(
+            ToolDownloaderPlugin.class,
+            plugin ->
+                plugin.registerToolIfAbsent(
+                    "graalvm",
+                    tool -> {
+                      tool.getVersion().set("1.0.0-rc8");
+                      tool.getBaseUrl().set("https://github.com/oracle/graal/releases/download/");
+                      tool.getArtifactPattern()
+                          .set("vm-[revision]/[artifact]-ce-[revision]-[classifier].[ext]");
+
+                      // Just use the linux binary to try the plugin on it, it'll fail at
+                      // runtime since Windows isn't supported yet.
+                      tool.getOsClassifiers().getWindows().set("linux-amd64");
+                      tool.getOsExtensions().getWindows().set("tar.gz");
+
+                      var pathBase = tool.getVersion().map(v -> "graalvm-ce-" + v);
+                      switch (new PlatformHelper().getOs()) {
+                        case LINUX:
+                        case WINDOWS:
+                          tool.getPathSubDirs().add(pathBase.map(p -> p + "/bin"));
+                          break;
+                        case MAC_OSX:
+                          tool.getPathSubDirs().add(pathBase.map(p -> p + "/Contents/Home/bin"));
+                          break;
+                      }
+                    }));
+  }
+}

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/tasks/NativeImageTask.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/tasks/NativeImageTask.java
@@ -1,0 +1,109 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.plugins.curioserver.tasks;
+
+import com.google.common.collect.Streams;
+import java.io.File;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.curioswitch.gradle.tooldownloader.DownloadedToolManager;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.plugins.ApplicationPluginConvention;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+public class NativeImageTask extends DefaultTask {
+
+  private final RegularFileProperty jarFile;
+  private final ConfigurableFileCollection classpath;
+  private final DirectoryProperty outputDir;
+  private final Property<String> outputName;
+
+  public NativeImageTask() {
+    jarFile = getProject().getLayout().fileProperty();
+    classpath = getProject().getLayout().configurableFiles();
+
+    outputDir = getProject().getLayout().directoryProperty();
+    outputDir.set(getProject().file("build/graal"));
+
+    outputName = getProject().getObjects().property(String.class);
+    outputName.set("app");
+  }
+
+  @InputFile
+  public RegularFileProperty getJarFile() {
+    return jarFile;
+  }
+
+  @InputFiles
+  public ConfigurableFileCollection getClasspath() {
+    return classpath;
+  }
+
+  @Input
+  public Property<String> getOutputName() {
+    return outputName;
+  }
+
+  @OutputDirectory
+  public DirectoryProperty getOutputDir() {
+    return outputDir;
+  }
+
+  @TaskAction
+  public void exec() {
+    var appPluginConvention =
+        getProject().getConvention().getPlugin(ApplicationPluginConvention.class);
+
+    String classpathArg =
+        Streams.concat(classpath.getFiles().stream(), Stream.of(jarFile.getAsFile().get()))
+            .map(File::getAbsolutePath)
+            .collect(Collectors.joining(":"));
+
+    getProject()
+        .exec(
+            exec -> {
+              exec.executable(
+                  DownloadedToolManager.get(getProject())
+                      .getBinDir("graalvm")
+                      .resolve("native-image"));
+              exec.args(
+                  "-cp",
+                  classpathArg,
+                  "-H:Path=",
+                  outputDir.getAsFile().get().getAbsolutePath(),
+                  "-H:Name=",
+                  outputName.get(),
+                  appPluginConvention.getMainClassName());
+            });
+  }
+}

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
@@ -294,6 +294,7 @@ public class CuriostackPlugin implements Plugin<Project> {
             .put("CatchFail", ERROR)
             .put("ClassCanBeStatic", ERROR)
             .put("ClassNewInstance", ERROR)
+            .put("CloseableProvides", OFF)
             .put("CollectionToArraySafeParameter", ERROR)
             .put("ComparableAndComparator", ERROR)
             .put("DateFormatConstant", ERROR)

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPlugin.java
@@ -393,7 +393,9 @@ public class CuriostackPlugin implements Plugin<Project> {
         .configureEach(
             task -> {
               task.getOptions().setIncremental(true);
-              task.getOptions().setCompilerArgs(ImmutableList.of("-XDcompilePolicy=byfile"));
+              task.getOptions()
+                  .setCompilerArgs(
+                      ImmutableList.of("-XDcompilePolicy=byfile", "-Adagger.gradle.incremental"));
               project
                   .getTasks()
                   .withType(SpotlessTask.class)
@@ -480,6 +482,7 @@ public class CuriostackPlugin implements Plugin<Project> {
     project
         .getDependencies()
         .add(ErrorPronePlugin.CONFIGURATION_NAME, "com.google.auto.value:auto-value-annotations");
+
     project.afterEvaluate(CuriostackPlugin::addStandardJavaTestDependencies);
 
     project

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -483,7 +483,6 @@ public class StandardDependencies {
           "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4",
           "com.netflix.nebula:gradle-dependency-lock-plugin:6.0.0",
           "com.netflix.nebula:gradle-resolution-rules-plugin:6.0.5",
-          "gradle.plugin.com.palantir.graal:gradle-graal:0.1.1-7-gdcfac74",
           "com.palantir:gradle-baseline-java:0.10.0",
           "de.undercouch:gradle-download-task:3.4.3",
           "gradle.plugin.com.boxfuse.client:gradle-plugin-publishing:5.2.0",

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -127,7 +127,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.api.grpc")
-              .version("1.28.0")
+              .version("1.31.0")
               .addModules("grpc-google-cloud-pubsub-v1")
               .build(),
           ImmutableDependencySet.builder()
@@ -147,7 +147,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.cloud")
-              .version("1.48.0")
+              .version("1.49.0")
               .addModules(
                   "google-cloud-bigquery",
                   "google-cloud-core",
@@ -180,7 +180,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.dagger")
-              .version("2.17")
+              .version("2.18")
               .addModules("dagger", "dagger-compiler", "dagger-producers")
               .build(),
           ImmutableDependencySet.builder()
@@ -195,7 +195,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.guava")
-              .version("26.0-jre")
+              .version("27.0-jre")
               .addModules("guava", "guava-testlib")
               .build(),
           ImmutableDependencySet.builder()
@@ -211,7 +211,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.linecorp.armeria")
-              .version("0.73.0")
+              .version("0.74.0")
               .addModules("armeria", "armeria-grpc", "armeria-retrofit2", "armeria-zipkin")
               .build(),
           ImmutableDependencySet.builder()
@@ -247,7 +247,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("info.solidsoft.mockito")
-              .version("2.4.0")
+              .version("2.5.0")
               .addModules("mockito-java8")
               .build(),
           ImmutableDependencySet.builder()
@@ -262,7 +262,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("io.lettuce")
-              .version("5.1.0.RELEASE")
+              .version("5.1.1.RELEASE")
               .addModules("lettuce-core")
               .build(),
           ImmutableDependencySet.builder()
@@ -281,7 +281,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("io.micrometer")
-              .version("1.0.6")
+              .version("1.0.7")
               .addModules("micrometer-core", "micrometer-registry-prometheus")
               .build(),
           ImmutableDependencySet.builder()
@@ -316,13 +316,13 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("io.zipkin.brave")
-              .version("5.4.2")
+              .version("5.4.3")
               .addModules("brave", "brave-instrumentation-mysql", "brave-instrumentation-mysql8")
               .build(),
           ImmutableDependencySet.builder()
               .group("io.zipkin.gcp")
-              .version("0.8.2")
-              .addModules("zipkin-propagation-stackdriver", "zipkin-translation-stackdriver")
+              .version("0.8.3")
+              .addModules("brave-propagation-stackdriver", "zipkin-translation-stackdriver")
               .build(),
           ImmutableDependencySet.builder()
               .group("javax.inject")
@@ -336,7 +336,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("net.bytebuddy")
-              .version("1.9.1")
+              .version("1.9.2")
               .addModules("byte-buddy", "byte-buddy-agent")
               .build(),
           ImmutableDependencySet.builder()
@@ -404,7 +404,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.curioswitch.curiostack")
-              .version("0.0.91")
+              .version("0.0.93")
               .addModules("curio-server-framework")
               .build(),
           ImmutableDependencySet.builder()
@@ -454,7 +454,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.mockito")
-              .version("2.23.0")
+              .version("2.23.1")
               .addModules("mockito-core", "mockito-junit-jupiter")
               .build(),
           ImmutableDependencySet.builder()
@@ -464,7 +464,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.simpleflatmapper")
-              .version("6.0.1")
+              .version("6.0.3")
               .addModules(
                   "sfm-converter", "sfm-jdbc", "sfm-jooq", "sfm-map", "sfm-reflect", "sfm-util")
               .build(),
@@ -476,17 +476,18 @@ public class StandardDependencies {
 
   static final ImmutableList<String> DEPENDENCIES =
       ImmutableList.of(
-          "com.bmuschko:gradle-docker-plugin:3.6.2",
+          "com.bmuschko:gradle-docker-plugin:4.0.1",
           "com.diffplug.spotless:spotless-plugin-gradle:3.15.0",
           "com.github.ben-manes:gradle-versions-plugin:0.20.0",
           "com.google.protobuf:protobuf-gradle-plugin:0.8.6",
           "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4",
           "com.netflix.nebula:gradle-dependency-lock-plugin:6.0.0",
           "com.netflix.nebula:gradle-resolution-rules-plugin:6.0.5",
+          "gradle.plugin.com.palantir.graal:gradle-graal:0.1.1-7-gdcfac74",
           "com.palantir:gradle-baseline-java:0.10.0",
           "de.undercouch:gradle-download-task:3.4.3",
-          "gradle.plugin.com.boxfuse.client:gradle-plugin-publishing:5.1.4",
-          "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:0.9.11",
+          "gradle.plugin.com.boxfuse.client:gradle-plugin-publishing:5.2.0",
+          "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:0.9.13",
           "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.5.2",
           "gradle.plugin.com.jetbrains.python:gradle-python-envs:0.0.25",
           "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0",
@@ -496,7 +497,7 @@ public class StandardDependencies {
           "javax.xml.bind:jaxb-api:2.3.0",
           "me.champeau.gradle:jmh-gradle-plugin:0.4.7",
           "mysql:mysql-connector-java:8.0.12",
-          "net.ltgt.gradle:gradle-apt-plugin:0.18",
+          "net.ltgt.gradle:gradle-apt-plugin:0.19",
           "net.ltgt.gradle:gradle-errorprone-plugin:0.6",
           "nu.studer:gradle-jooq-plugin:3.0.2");
 

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -404,7 +404,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.curioswitch.curiostack")
-              .version("0.0.93")
+              .version("0.0.94")
               .addModules("curio-server-framework")
               .build(),
           ImmutableDependencySet.builder()

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/CurioDatabasePlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/CurioDatabasePlugin.java
@@ -25,11 +25,7 @@
 package org.curioswitch.gradle.plugins.gcloud;
 
 import com.bmuschko.gradle.docker.DockerRemoteApiPlugin;
-import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage;
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile;
-import com.google.common.collect.ImmutableList;
-import org.curioswitch.gradle.plugins.gcloud.tasks.DeployDevDbPodTask;
-import org.curioswitch.gradle.plugins.gcloud.tasks.GcloudTask;
 import org.flywaydb.gradle.FlywayExtension;
 import org.flywaydb.gradle.FlywayPlugin;
 import org.gradle.api.Plugin;
@@ -70,22 +66,5 @@ public class CurioDatabasePlugin implements Plugin<Project> {
       // Root privilege needs to be exposed to create users other than MYSQL_USER.
       generateDevDbDockerfile.environmentVariable("MYSQL_ROOT_PASSWORD", devAdminPassword);
     }
-
-    DockerBuildImage buildDevDbDockerImage =
-        project.getTasks().create("buildDevDbDockerImage", DockerBuildImage.class);
-    buildDevDbDockerImage.dependsOn(generateDevDbDockerfile);
-    buildDevDbDockerImage.setInputDir(generateDevDbDockerfile.getDestFile().getParentFile());
-    buildDevDbDockerImage.setTag(config.devDockerImageTag());
-
-    GcloudTask pushDevDbDockerImage =
-        project.getTasks().create("pushDevDbDockerImage", GcloudTask.class);
-    pushDevDbDockerImage.dependsOn(buildDevDbDockerImage);
-    pushDevDbDockerImage.setArgs(
-        ImmutableList.of("docker", "--", "push", config.devDockerImageTag()));
-
-    project
-        .getTasks()
-        .create("deployDevDb", DeployDevDbPodTask.class)
-        .dependsOn(pushDevDbDockerImage);
   }
 }

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/terraform/TerraformSetupPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/terraform/TerraformSetupPlugin.java
@@ -32,7 +32,6 @@ import org.curioswitch.gradle.golang.GolangSetupPlugin;
 import org.curioswitch.gradle.golang.tasks.GoTask;
 import org.curioswitch.gradle.helpers.platform.PathUtil;
 import org.curioswitch.gradle.plugins.curiostack.StandardDependencies;
-import org.curioswitch.gradle.plugins.terraform.tasks.DownloadTerraformPluginTask;
 import org.curioswitch.gradle.tooldownloader.DownloadedToolManager;
 import org.curioswitch.gradle.tooldownloader.ToolDownloaderPlugin;
 import org.curioswitch.gradle.tooldownloader.util.DownloadToolUtil;
@@ -111,48 +110,14 @@ public class TerraformSetupPlugin implements Plugin<Project> {
             .getTasks()
             .register(
                 "terraformDownloadKubernetesForkProvider",
-                DownloadTerraformPluginTask.class,
-                "github.com/anuraaga/terraform-provider-kubernetes",
-                "48a08093b8723473929e8132b7ccf9e0a61e23b9");
-
-    var terraformInstallKubernetesForm =
-        project
-            .getTasks()
-            .register(
-                "terraformInstallKubernetesForkProvider",
                 GoTask.class,
                 t -> {
-                  t.dependsOn(terraformDownloadKubernetesFork);
-                  t.args("install", "-mod=vendor");
+                  t.args("get", "github.com/sl1pm4t/terraform-provider-kubernetes");
                   t.onlyIf(
                       unused ->
                           !Files.exists(
-                              DownloadedToolManager.get(project)
-                                  .getBinDir("terraform")
-                                  .resolve(PathUtil.getExeName("terraform-provider-kubernetes"))));
-                  t.execCustomizer(
-                      exec ->
-                          exec.workingDir(
-                              terraformDownloadKubernetesFork
-                                  .get()
-                                  .getTemporaryDir()
-                                  .toPath()
-                                  .resolve(
-                                      "terraform-provider-kubernetes-48a08093b8723473929e8132b7ccf9e0a61e23b9")));
-                });
-
-    var terraformDownloadHelm =
-        project
-            .getTasks()
-            .register(
-                "terraformDownloadHelmProvider",
-                GoTask.class,
-                t -> {
-                  t.args("get", "github.com/mcuadros/terraform-provider-helm");
-                  t.onlyIf(
-                      unused ->
-                          !Files.exists(
-                              goBinDir.resolve(PathUtil.getExeName("terraform-provider-helm"))));
+                              goBinDir.resolve(
+                                  PathUtil.getExeName("terraform-provider-kubernetes"))));
                 });
 
     var terraformDownloadGsuite =
@@ -178,8 +143,7 @@ public class TerraformSetupPlugin implements Plugin<Project> {
                 t -> {
                   t.dependsOn(
                       terraformDownloadK8s,
-                      terraformDownloadHelm,
-                      terraformInstallKubernetesForm,
+                      terraformDownloadKubernetesFork,
                       terraformDownloadGsuite);
                   t.into(DownloadedToolManager.get(project).getBinDir("terraform"));
                   t.from(goBinDir);


### PR DESCRIPTION
- Add `@CloseOnStop` annotation to allow modules to provide objects that are closed after server stop
- Allow setting database connection max lifetime and set it to a high value to match MySQL default, which is recommended when apps use managed connection pool
- Use SLF4J mysql logger so exceptions don't spam stderr
- (untested) Enable firebase authentication of debug requests
- Experimental support for generating native images for java binaries. Likely only works for very simple, non-gRPC ones for now
- Enable forgotten logging of armeria client request errors
- Adds a flag that can be used to enable fine-grained tracing of producer execution. Creates overhead and lots of spans but can be the last mile when debugging performance issues
- Uses upstream helm provider + kubernetes fork provider for terraform
- Update dependencies