### PR TITLE
Fix configuration of gcloud tasks to work properly.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-org.curioswitch.curiostack.version = 0.0.171
+org.curioswitch.curiostack.version = 0.0.171.1
 
 org.gradle.caching = true
 # org.gradle.configureondemand = true

--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.171
+version = 0.0.171.1

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
@@ -220,19 +220,15 @@ public class GcloudPlugin implements Plugin<Project> {
 
                                   // We disable cache upload by default and only enable it if a
                                   // setup task was run.
-                                  uploadCache.configure(t -> t.setOnlyIf(unused -> false));
-                                  DownloadToolUtil.getSetupTask(project, tool.getName())
-                                      .configure(
-                                          t ->
-                                              uploadCache.configure(
-                                                  uc ->
-                                                      uc.setOnlyIf(
-                                                          unused ->
-                                                              "true"
-                                                                      .equals(
-                                                                          System.getenv(
-                                                                              "CI_MASTER"))
-                                                                  && t.getDidWork())));
+                                  uploadCache.configure(
+                                      uc ->
+                                          uc.setOnlyIf(
+                                              unused ->
+                                                  "true".equals(System.getenv("CI_MASTER"))
+                                                      && DownloadToolUtil.getSetupTask(
+                                                              project, tool.getName())
+                                                          .get()
+                                                          .getDidWork()));
 
                                   project
                                       .getPlugins()


### PR DESCRIPTION
- Curiostack doesn't override `PATH` completely anymore. Commands will use curiostack versions when the current directory is within a curiostack repository, and system ones elsewhere
- Adds armeria based pubsub library
- OpenJDK automatically downloaded (IntelliJ still needs manual setup)
- Update dependencies
  - Gradle 5
  - Armeria 0.75