### PR TITLE
Curio 175

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,6 +53,9 @@ steps:
   env:
   - CI=true
   - CI_MASTER=true
+  - CLOUDBUILD_BUILD_ID=$_BUILD_ID
+  secretEnv:
+    - CODECOV_TOKEN
 - id: curio-generated-push-compressed-build-cache
   waitFor:
   - curio-generated-build-all
@@ -68,3 +71,8 @@ steps:
   - -c
   - tar -cpf - wrapper caches curiostack/gcloud curiostack/miniconda2-build | lz4 -qc - | gsutil -o GSUtil:parallel_composite_upload_threshold=150M cp - gs://curioswitch-gradle-build-cache/cloudbuild-cache-compressed.tar.lz4
 timeout: 60m
+secrets:
+- kmsKeyName: projects/curioswitch-cluster/locations/us-central1/keyRings/cloudbuild/cryptoKeys/github
+  secretEnv:
+    CODECOV_TOKEN: CiQAxdYgHOdQ5tY7WYjvBYlUsXk9g4GvELjEJZhEIFcxrkuDKY4STQA/OpLB7g9Gr8K5MZrwZXVDH/Ste1P6ZOFJl0TYILjU31c72w8Mmhde5JJv1VyEHW+67h8UARJHh6yOktrGFBU6wGzKDud0p6az3PoW
+

--- a/common/google-cloud/core/src/test/java/org/curioswitch/curiostack/gcloud/core/util/AsyncRefreshingValueTest.java
+++ b/common/google-cloud/core/src/test/java/org/curioswitch/curiostack/gcloud/core/util/AsyncRefreshingValueTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.curiostack.gcloud.core.util;
+
+import org.junit.jupiter.api.Test;
+
+class AsyncRefreshingValueTest {
+
+  @Test
+  void normal() {}
+}

--- a/common/google-cloud/pubsub/src/test/java/org/curioswitch/gcloud/pubsub/PublisherTest.java
+++ b/common/google-cloud/pubsub/src/test/java/org/curioswitch/gcloud/pubsub/PublisherTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gcloud.pubsub;
+
+import org.junit.jupiter.api.Test;
+
+class PublisherTest {
+
+  @Test
+  void normal() {}
+}

--- a/eggworld/server/src/test/java/org/curioswitch/eggworld/server/util/IngredientConverterTest.java
+++ b/eggworld/server/src/test/java/org/curioswitch/eggworld/server/util/IngredientConverterTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.eggworld.server.util;
+
+import org.junit.jupiter.api.Test;
+
+class IngredientConverterTest {
+
+  @Test
+  void normal() {}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-org.curioswitch.curiostack.version = 0.0.174.2
+org.curioswitch.curiostack.version = 0.0.175
 
 org.gradle.caching = true
 # org.gradle.configureondemand = true

--- a/tools/cloudbuild-github-functions/config.yml
+++ b/tools/cloudbuild-github-functions/config.yml
@@ -73,8 +73,13 @@ repos:
           - --no-daemon
           env:
             - CI=true
+            - GITHUB_PR_REMOTE_REF=$_OTHER_BRANCH_REMOTE_REF
+            - CLOUDBUILD_BUILD_ID=$_BUILD_ID
+          secretEnv:
+            - CODECOV_TOKEN
       timeout: 60m
       secrets:
         - kmsKeyName: projects/curioswitch-cluster/locations/us-central1/keyRings/cloudbuild/cryptoKeys/github
           secretEnv:
             GITHUB_TOKEN: CiQAxdYgHKy7zJMVlxWy8cIw05kknrquhxEOlNjZyZlWoj5Cnc8SUQA/OpLBO9ycMNajhYGLluk2Kji4Do5vT9DqV/zVmFdJ7orxk6n0bTw8cUY+gjp8IohjMdpt8ElWrRkChYzY2FLQIlGo+eldnEPUttZg1vWDjA==
+            CODECOV_TOKEN: CiQAxdYgHOdQ5tY7WYjvBYlUsXk9g4GvELjEJZhEIFcxrkuDKY4STQA/OpLB7g9Gr8K5MZrwZXVDH/Ste1P6ZOFJl0TYILjU31c72w8Mmhde5JJv1VyEHW+67h8UARJHh6yOktrGFBU6wGzKDud0p6az3PoW

--- a/tools/gradle-plugins/gradle-conda-plugin/src/test/java/org/curioswitch/gradle/conda/exec/CondaExecUtilTest.java
+++ b/tools/gradle-plugins/gradle-conda-plugin/src/test/java/org/curioswitch/gradle/conda/exec/CondaExecUtilTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.conda.exec;
+
+import org.junit.jupiter.api.Test;
+
+class CondaExecUtilTest {
+
+  @Test
+  void normal() {}
+}

--- a/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.174.2
+version = 0.0.175

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/ci/tasks/FetchCodeCovCacheTask.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/ci/tasks/FetchCodeCovCacheTask.java
@@ -22,48 +22,52 @@
  * SOFTWARE.
  */
 
-package org.curioswitch.gradle.plugins.gcloud.tasks;
+package org.curioswitch.gradle.plugins.ci.tasks;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
-import org.apache.tools.ant.taskdefs.condition.Os;
+import org.curioswitch.gradle.helpers.platform.OperatingSystem;
+import org.curioswitch.gradle.helpers.platform.PlatformHelper;
 import org.curioswitch.gradle.tooldownloader.DownloadedToolManager;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerExecutor;
 
-public class UploadToolCacheTask extends DefaultTask {
+public class FetchCodeCovCacheTask extends DefaultTask {
 
   // It is extremely hacky to use global state to propagate the Task to workers, but
   // it works so let's enjoy the speed.
-  private static final ConcurrentHashMap<String, UploadToolCacheTask> TASKS =
+  private static final ConcurrentHashMap<String, FetchCodeCovCacheTask> TASKS =
       new ConcurrentHashMap<>();
 
-  private final Property<String> dest;
-  private final ListProperty<String> srcPaths;
+  private final Property<String> src;
 
   private final WorkerExecutor workerExecutor;
 
   @Inject
-  public UploadToolCacheTask(WorkerExecutor workerExecutor) {
+  public FetchCodeCovCacheTask(WorkerExecutor workerExecutor) {
     this.workerExecutor = workerExecutor;
 
-    dest = getProject().getObjects().property(String.class);
-    srcPaths = getProject().getObjects().listProperty(String.class).empty();
-
-    onlyIf(unused -> "true".equals(System.getenv("CI_MASTER")));
+    src = getProject().getObjects().property(String.class);
   }
 
-  public UploadToolCacheTask setDest(String dest) {
-    this.dest.set(dest);
+  @Input
+  public Property<String> getSrc() {
+    return src;
+  }
+
+  public FetchCodeCovCacheTask setSrc(String src) {
+    this.src.set(src);
     return this;
   }
 
-  public UploadToolCacheTask srcPath(String srcPath) {
-    this.srcPaths.add(srcPath);
+  public FetchCodeCovCacheTask setSrc(Provider<String> src) {
+    this.src.set(src);
     return this;
   }
 
@@ -72,37 +76,43 @@ public class UploadToolCacheTask extends DefaultTask {
     String mapKey = UUID.randomUUID().toString();
     TASKS.put(mapKey, this);
 
-    // We usually execute long-running tasks in the executor but directly run for now since gsutil
-    // seems to be flaky under high concurrency.
-    new DoUploadToolCache(mapKey).run();
+    workerExecutor.submit(
+        FetchReports.class,
+        config -> {
+          config.setIsolationMode(IsolationMode.NONE);
+          config.params(mapKey);
+        });
   }
 
-  public static class DoUploadToolCache implements Runnable {
+  public static class FetchReports implements Runnable {
+
     private final String mapKey;
 
     @Inject
-    public DoUploadToolCache(String mapKey) {
+    public FetchReports(String mapKey) {
       this.mapKey = mapKey;
     }
 
     @Override
     public void run() {
-      UploadToolCacheTask task = TASKS.remove(mapKey);
+      var task = TASKS.remove(mapKey);
+
       var toolManager = DownloadedToolManager.get(task.getProject());
-      String gsutil = Os.isFamily(Os.FAMILY_WINDOWS) ? "gsutil" + ".cmd" : "gsutil";
+
+      String gsutil =
+          new PlatformHelper().getOs() == OperatingSystem.WINDOWS ? "gsutil.cmd" : "gsutil";
+
       task.getProject()
           .exec(
               exec -> {
                 exec.executable("bash");
-                exec.workingDir(toolManager.getCuriostackDir());
+
                 exec.args(
-                    "-c",
-                    "tar -cpf - "
-                        + String.join(" ", task.srcPaths.get())
-                        + " | lz4 -qc - |"
-                        + gsutil
-                        + " -o GSUtil:parallel_composite_upload_threshold=150M cp - "
-                        + task.dest.get());
+                    "-c", gsutil + " cp " + task.src.get() + " - | tar -xpz --skip-old-files");
+
+                exec.setIgnoreExitValue(true);
+
+                toolManager.addAllToPath(exec);
               });
     }
   }

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/StandardDependencies.java
@@ -46,11 +46,11 @@ public class StandardDependencies {
     String version();
   }
 
-  public static final String GCLOUD_VERSION = "227.0.0";
+  public static final String GCLOUD_VERSION = "228.0.0";
   public static final String HELM_VERSION = "2.10.0";
   public static final String MINICONDA_VERSION = "4.5.11";
-  public static final String TERRAFORM_VERSION = "0.11.10";
-  public static final String NODE_VERSION = "10.14.1";
+  public static final String TERRAFORM_VERSION = "0.11.11";
+  public static final String NODE_VERSION = "10.14.2";
   public static final String YARN_VERSION = "1.12.3";
 
   static final String GOOGLE_JAVA_FORMAT_VERSION = "1.6";
@@ -122,12 +122,12 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.api.grpc")
-              .version("0.38.0")
+              .version("0.39.0")
               .addModules("grpc-google-cloud-trace-v1")
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.api.grpc")
-              .version("1.37.0")
+              .version("1.38.0")
               .addModules("grpc-google-cloud-pubsub-v1")
               .build(),
           ImmutableDependencySet.builder()
@@ -142,7 +142,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("com.google.cloud")
-              .version("1.55.0")
+              .version("1.56.0")
               .addModules(
                   "google-cloud-bigquery",
                   "google-cloud-core",
@@ -331,7 +331,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("net.bytebuddy")
-              .version("1.9.5")
+              .version("1.9.6")
               .addModules("byte-buddy", "byte-buddy-agent")
               .build(),
           ImmutableDependencySet.builder()
@@ -459,7 +459,7 @@ public class StandardDependencies {
               .build(),
           ImmutableDependencySet.builder()
               .group("org.simpleflatmapper")
-              .version("6.0.11")
+              .version("6.0.12")
               .addModules(
                   "sfm-converter", "sfm-jdbc", "sfm-jooq", "sfm-map", "sfm-reflect", "sfm-util")
               .build(),
@@ -472,7 +472,7 @@ public class StandardDependencies {
   static final ImmutableList<String> DEPENDENCIES =
       ImmutableList.of(
           "com.bmuschko:gradle-docker-plugin:4.1.0",
-          "com.diffplug.spotless:spotless-plugin-gradle:3.16.0",
+          "com.diffplug.spotless:spotless-plugin-gradle:3.17.0",
           "com.github.ben-manes:gradle-versions-plugin:0.20.0",
           "com.google.gradle:osdetector-gradle-plugin:1.6.0",
           "com.google.protobuf:protobuf-gradle-plugin:0.8.6",

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
@@ -46,6 +46,8 @@ import org.curioswitch.gradle.conda.CondaPlugin;
 import org.curioswitch.gradle.conda.ModifiableCondaExtension;
 import org.curioswitch.gradle.helpers.task.TaskUtil;
 import org.curioswitch.gradle.plugins.ci.CurioGenericCiPlugin;
+import org.curioswitch.gradle.plugins.ci.tasks.FetchCodeCovCacheTask;
+import org.curioswitch.gradle.plugins.ci.tasks.UploadCodeCovCacheTask;
 import org.curioswitch.gradle.plugins.curioserver.CurioServerPlugin;
 import org.curioswitch.gradle.plugins.curioserver.DeploymentExtension;
 import org.curioswitch.gradle.plugins.gcloud.tasks.FetchToolCacheTask;
@@ -165,6 +167,25 @@ public class GcloudPlugin implements Plugin<Project> {
         p -> {
           ImmutableGcloudExtension config =
               project.getExtensions().getByType(GcloudExtension.class);
+
+          project
+              .getTasks()
+              .withType(UploadCodeCovCacheTask.class)
+              .configureEach(
+                  t ->
+                      t.setDest(
+                          "gs://"
+                              + config.buildCacheStorageBucket()
+                              + "/cloudbuild-cache-codecov.tar.gz"));
+          project
+              .getTasks()
+              .withType(FetchCodeCovCacheTask.class)
+              .configureEach(
+                  t ->
+                      t.setSrc(
+                          "gs://"
+                              + config.buildCacheStorageBucket()
+                              + "/cloudbuild-cache-codecov.tar.gz"));
 
           if (System.getenv("CI") != null) {
             project

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/test/java/org/curioswitch/gradle/plugins/gcloud/buildcache/CloudStorageBuildCacheServiceTest.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/test/java/org/curioswitch/gradle/plugins/gcloud/buildcache/CloudStorageBuildCacheServiceTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.plugins.gcloud.buildcache;
+
+import org.junit.jupiter.api.Test;
+
+class CloudStorageBuildCacheServiceTest {
+
+  @Test
+  void normal() {}
+}

--- a/tools/gradle-plugins/gradle-golang-plugin/src/test/java/org/curioswitch/gradle/golang/GoExecUtilTest.java
+++ b/tools/gradle-plugins/gradle-golang-plugin/src/test/java/org/curioswitch/gradle/golang/GoExecUtilTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.golang;
+
+import org.junit.jupiter.api.Test;
+
+class GoExecUtilTest {
+
+  @Test
+  void normal() {}
+}

--- a/tools/gradle-plugins/gradle-helpers/src/test/java/org/curioswitch/gradle/helpers/platform/PlatformHelperTest.java
+++ b/tools/gradle-plugins/gradle-helpers/src/test/java/org/curioswitch/gradle/helpers/platform/PlatformHelperTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.helpers.platform;
+
+import org.junit.jupiter.api.Test;
+
+class PlatformHelperTest {
+
+  @Test
+  void normal() {}
+}

--- a/tools/gradle-plugins/gradle-protobuf-plugin/src/test/java/org/curioswitch/gradle/protobuf/utils/SourceSetUtilsTest.java
+++ b/tools/gradle-plugins/gradle-protobuf-plugin/src/test/java/org/curioswitch/gradle/protobuf/utils/SourceSetUtilsTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.protobuf.utils;
+
+import org.junit.jupiter.api.Test;
+
+class SourceSetUtilsTest {
+
+  @Test
+  void normal() {}
+}

--- a/tools/gradle-plugins/gradle-tool-downloader-plugin/src/test/java/org/curioswitch/gradle/tooldownloader/util/DownloadToolUtilTest.java
+++ b/tools/gradle-plugins/gradle-tool-downloader-plugin/src/test/java/org/curioswitch/gradle/tooldownloader/util/DownloadToolUtilTest.java
@@ -1,0 +1,33 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.tooldownloader.util;
+
+import org.junit.jupiter.api.Test;
+
+class DownloadToolUtilTest {
+
+  @Test
+  void normal() {}
+}


### PR DESCRIPTION
- Set PR number for codecov reports
- Propagate codecov reports across builds so every commit has a full coverage report even when skipping build tasks
- Update dependencies