### PR TITLE
Resetting state - Return globalInitialState which has language and route reducers.

### DIFF
--- a/common/web/base-web/src/state/store.ts
+++ b/common/web/base-web/src/state/store.ts
@@ -136,7 +136,7 @@ export default function configureStore<S extends object>(
   store.nonInjectedReducers = nonInjectedReducers;
   store.injectedReducers = {}; // Reducer registry
   store.injectedSagas = {}; // Saga registry
-  store.initialState = initialState;
+  store.initialState = globalInitialState;
   // Make reducers hot reloadable, see http://mxs.is/googmo
   /* istanbul ignore next */
   if (module.hot) {


### PR DESCRIPTION
Might fix console error: `The previous state received by the reducer is of unexpected type. Expected argument to be an instance of Immutable.Collection or Immutable.Record with the following properties: [...]`