### PR TITLE
Add a option to disable EDNS for google API client

### DIFF
--- a/common/google-cloud/core/src/main/java/org/curioswitch/curiostack/gcloud/core/GcloudConfig.java
+++ b/common/google-cloud/core/src/main/java/org/curioswitch/curiostack/gcloud/core/GcloudConfig.java
@@ -39,4 +39,10 @@ import org.immutables.value.Value.Style.BuilderVisibility;
     defaultAsDefault = true)
 public interface GcloudConfig {
   String getProject();
+
+  /**
+   * Whether EDNS should be disabled in clients. This is required when connecting to a server in an
+   * environment with a DNS server that doesn't support EDNS.
+   */
+  boolean getDisableEdns();
 }

--- a/common/google-cloud/core/src/main/java/org/curioswitch/curiostack/gcloud/core/GcloudModule.java
+++ b/common/google-cloud/core/src/main/java/org/curioswitch/curiostack/gcloud/core/GcloudModule.java
@@ -35,16 +35,12 @@ import com.linecorp.armeria.client.retry.RetryStrategy;
 import com.linecorp.armeria.client.retry.RetryingHttpClient;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.internal.TransportType;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigBeanFactory;
 import dagger.BindsOptionalOf;
 import dagger.Module;
 import dagger.Provides;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.netty.resolver.dns.DnsAddressResolverGroup;
-import io.netty.resolver.dns.DnsNameResolverBuilder;
-import io.netty.resolver.dns.DnsServerAddressStreamProviders;
 import java.util.Optional;
 import javax.inject.Singleton;
 import org.curioswitch.curiostack.gcloud.core.auth.GcloudAuthModule;
@@ -73,14 +69,8 @@ public abstract class GcloudModule {
                 registry -> {
                   ClientFactoryBuilder builder = new ClientFactoryBuilder().meterRegistry(registry);
                   if (config.getDisableEdns()) {
-                    builder.addressResolverGroupFactory(
-                        eventLoopGroup ->
-                            new DnsAddressResolverGroup(
-                                new DnsNameResolverBuilder()
-                                    .channelType(TransportType.datagramChannelType(eventLoopGroup))
-                                    .nameServerProvider(
-                                        DnsServerAddressStreamProviders.platformDefault())
-                                    .optResourceEnabled(false)));
+                    builder.domainNameResolverCustomizer(
+                        dnsNameResolverBuilder -> dnsNameResolverBuilder.optResourceEnabled(false));
                   }
                   return builder.build();
                 })

--- a/common/google-cloud/core/src/main/resources/reference.conf
+++ b/common/google-cloud/core/src/main/resources/reference.conf
@@ -24,6 +24,7 @@
 
 gcloud {
   project: ""
+  disableEdns: false
 
   auth {
     serviceAccountBase64: ""

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/buildcache/CloudStorageBuildCacheServiceFactory.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/buildcache/CloudStorageBuildCacheServiceFactory.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.time.Clock;
 import java.util.Optional;
 import org.curioswitch.curiostack.gcloud.core.GcloudModule;
+import org.curioswitch.curiostack.gcloud.core.ModifiableGcloudConfig;
 import org.curioswitch.curiostack.gcloud.core.auth.AccessTokenProvider;
 import org.curioswitch.curiostack.gcloud.core.auth.GcloudAuthModule;
 import org.curioswitch.curiostack.gcloud.core.auth.GoogleCredentialsDecoratingClient;
@@ -69,7 +70,8 @@ public class CloudStorageBuildCacheServiceFactory
       return new NoOpBuildCacheService();
     }
 
-    HttpClient googleApis = GcloudModule.googleApisClient(Optional.empty());
+    ModifiableGcloudConfig config = new ModifiableGcloudConfig()
+    HttpClient googleApis = GcloudModule.googleApisClient(Optional.empty(), config);
     AccessTokenProvider.Factory accessTokenProviderFactory =
         new AccessTokenProvider.Factory(googleApis, Clock.systemUTC());
     AccessTokenProvider accessTokenProvider = accessTokenProviderFactory.create(credentials);

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/buildcache/CloudStorageBuildCacheServiceFactory.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/buildcache/CloudStorageBuildCacheServiceFactory.java
@@ -70,7 +70,7 @@ public class CloudStorageBuildCacheServiceFactory
       return new NoOpBuildCacheService();
     }
 
-    ModifiableGcloudConfig config = new ModifiableGcloudConfig()
+    ModifiableGcloudConfig config = new ModifiableGcloudConfig();
     HttpClient googleApis = GcloudModule.googleApisClient(Optional.empty(), config);
     AccessTokenProvider.Factory accessTokenProviderFactory =
         new AccessTokenProvider.Factory(googleApis, Clock.systemUTC());


### PR DESCRIPTION
ServerModule already has a option to disable EDNS. Because I'd like to use same option for HTTP API client used by StorageModule, I added it to GcloudModule.