### PR TITLE
Add support for recent JsonFormat features.

### DIFF
--- a/common/grpc/protobuf-jackson/build.gradle
+++ b/common/grpc/protobuf-jackson/build.gradle
@@ -30,13 +30,8 @@ apply plugin: 'org.curioswitch.gradle-grpc-api-plugin'
 
 archivesBaseName = 'protobuf-jackson'
 
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
-
-[tasks.compileTestJava, tasks.compileJmhJava].each {
-    it.sourceCompatibility = '1.8'
-    it.targetCompatibility = '1.8'
-}
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
 
 // Not clear why this doesn't happen automatically with the configuration extension.
 tasks.compileJmhJava.dependsOn tasks.compileTestJava

--- a/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/SerializeSupport.java
+++ b/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/SerializeSupport.java
@@ -31,7 +31,12 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Message;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public final class SerializeSupport {
 
@@ -239,6 +244,25 @@ public final class SerializeSupport {
     s.asQuotedUTF8();
     s.asUnquotedUTF8();
     return s;
+  }
+
+  private static final Comparator<Entry<String, ?>> STRING_KEY_COMPARATOR =
+      (o1, o2) -> {
+        ByteString s1 = ByteString.copyFromUtf8(o1.getKey());
+        ByteString s2 = ByteString.copyFromUtf8(o2.getKey());
+        return ByteString.unsignedLexicographicalComparator().compare(s1, s2);
+      };
+
+  public static Iterator<? extends Entry> mapIterator(
+      Map<?, ?> map, boolean sortingMapKeys, boolean stringKey) {
+    if (!sortingMapKeys) {
+      return map.entrySet().iterator();
+    }
+
+    Comparator cmp = stringKey ? STRING_KEY_COMPARATOR : Map.Entry.comparingByKey();
+    List<Entry<?, ?>> sorted = new ArrayList<>(map.entrySet());
+    sorted.sort(cmp);
+    return sorted.iterator();
   }
 
   private SerializeSupport() {}

--- a/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/TypeSpecificMarshaller.java
+++ b/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/TypeSpecificMarshaller.java
@@ -151,6 +151,8 @@ public abstract class TypeSpecificMarshaller<T extends Message> {
       boolean includingDefaultValueFields,
       boolean preservingProtoFieldNames,
       boolean ignoringUnknownFields,
+      boolean printingEnumsAsInts,
+      boolean sortingMapKeys,
       Map<Descriptor, TypeSpecificMarshaller<?>> builtMarshallers) {
     if (builtMarshallers.containsKey(prototype.getDescriptorForType())) {
       return;
@@ -160,6 +162,8 @@ public abstract class TypeSpecificMarshaller<T extends Message> {
         includingDefaultValueFields,
         preservingProtoFieldNames,
         ignoringUnknownFields,
+        printingEnumsAsInts,
+        sortingMapKeys,
         builtMarshallers);
     Map<String, TypeSpecificMarshaller<?>> builtMarshallersByFieldName = new HashMap<>();
     for (Map.Entry<Descriptor, TypeSpecificMarshaller<?>> entry : builtMarshallers.entrySet()) {
@@ -189,6 +193,8 @@ public abstract class TypeSpecificMarshaller<T extends Message> {
       boolean includingDefaultValueFields,
       boolean preservingProtoFieldNames,
       boolean ignoringUnknownFields,
+      boolean printingEnumsAsInts,
+      boolean sortingMapKeys,
       Map<Descriptor, TypeSpecificMarshaller<?>> alreadyBuiltMarshallers) {
     Descriptor descriptor = prototype.getDescriptorForType();
     if (alreadyBuiltMarshallers.containsKey(descriptor)) {
@@ -260,7 +266,9 @@ public abstract class TypeSpecificMarshaller<T extends Message> {
             .withParameter(prototype.getClass(), "message")
             .withParameter(JsonGenerator.class, "gen")
             .throwing(IOException.class)
-            .intercept(new DoWrite(prototype, includingDefaultValueFields));
+            .intercept(
+                new DoWrite(
+                    prototype, includingDefaultValueFields, printingEnumsAsInts, sortingMapKeys));
     try {
       marshaller =
           buddy
@@ -286,6 +294,8 @@ public abstract class TypeSpecificMarshaller<T extends Message> {
           includingDefaultValueFields,
           preservingProtoFieldNames,
           ignoringUnknownFields,
+          printingEnumsAsInts,
+          sortingMapKeys,
           alreadyBuiltMarshallers);
     }
   }

--- a/common/grpc/protobuf-jackson/src/test/proto/com/google/protobuf/util/json_test.proto
+++ b/common/grpc/protobuf-jackson/src/test/proto/com/google/protobuf/util/json_test.proto
@@ -71,6 +71,17 @@ message TestAllTypes {
     BAR = 1;
     BAZ = 2;
   }
+
+  enum AliasedEnum {
+    option allow_alias = true;
+
+    ALIAS_FOO = 0;
+    ALIAS_BAR = 1;
+    ALIAS_BAZ = 2;
+    QUX = 2;
+    qux = 2;
+    bAz = 2;
+  }
   message NestedMessage {
     int32 value = 1;
   }
@@ -92,6 +103,7 @@ message TestAllTypes {
   bytes optional_bytes = 15;
   NestedMessage optional_nested_message = 18;
   NestedEnum optional_nested_enum = 21;
+  AliasedEnum optional_aliased_enum = 52;
 
   // Repeated
   repeated int32 repeated_int32 = 31;


### PR DESCRIPTION
- printingEnumsAsInts
- sortingMapKeys
- unknown enum values are properly handled
- Unit test coverage is synced to completely match upstream
- Min java version raised to 8 given general deprecation of 7 across the ecosystem