### PR TITLE
Install bzip2 in cloud builder.

### DIFF
--- a/tools/build-images/java-cloud-builder/Dockerfile
+++ b/tools/build-images/java-cloud-builder/Dockerfile
@@ -31,7 +31,7 @@ FROM google/cloud-sdk:slim AS gcloud
 FROM openjdk:11-jdk-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python2.7-minimal libpython2.7-stdlib liblz4-tool libatomic1 && \
+    apt-get install -y --no-install-recommends python2.7-minimal libpython2.7-stdlib liblz4-tool libatomic1 bzip2 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
bzip2 disappeared from the openjdk docker images we use as a base for building. It is a common enough utility and tiny enough to go ahead and install (libbz2 is already present this just adds the executable so especially small delta).

Fixes #318 