### PR TITLE
Add gradle-test-helpers and clean up plugin tests.

### DIFF
--- a/project.settings.gradle.kts
+++ b/project.settings.gradle.kts
@@ -63,6 +63,7 @@ include(":tools:gradle-plugins:gradle-golang-plugin")
 include(":tools:gradle-plugins:gradle-helpers")
 include(":tools:gradle-plugins:gradle-protobuf-plugin")
 include(":tools:gradle-plugins:gradle-release-plugin")
+include(":tools:gradle-plugins:gradle-test-helpers")
 include(":tools:gradle-plugins:gradle-tool-downloader-plugin")
 include(":tools:gradle-plugins:java-groovy-compat")
 // curio-auto-generated DO NOT MANUALLY EDIT

--- a/tools/gradle-plugins/gradle-curiostack-plugin/build.gradle
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/build.gradle
@@ -104,6 +104,8 @@ dependencies {
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value-annotations'
+
+    testCompile project(':tools:gradle-plugins:gradle-test-helpers')
 }
 
 gradlePlugin {
@@ -186,4 +188,15 @@ publishing {
 // TODO(choko): Figure out how to disable license check of baseline config and reenable.
 tasks.withType(License) {
     enabled = false
+}
+
+tasks.withType(Test) {
+    jvmArgs "-Dorg.curioswitch.curiostack.testing.buildDir=${buildDir}"
+}
+
+// TODO(choko): Have curiostack plugin do this.
+test {
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/test/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPluginToolsTest.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/test/java/org/curioswitch/gradle/plugins/curiostack/CuriostackPluginToolsTest.java
@@ -24,21 +24,20 @@
 
 package org.curioswitch.gradle.plugins.curiostack;
 
-import static org.curioswitch.common.testing.assertj.CurioAssertions.assertThat;
-import static org.curioswitch.gradle.plugins.testutil.ResourceProjects.copyProjectFromResources;
+import static org.curioswitch.gradle.testing.assertj.CurioGradleAssertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.nio.file.Path;
+import org.curioswitch.gradle.testing.GradleTempDirectories;
+import org.curioswitch.gradle.testing.ResourceProjects;
 import org.gradle.api.Project;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 
 // This test is slow since it downloads a file, just run locally for now.
@@ -61,24 +60,23 @@ class CuriostackPluginToolsTest {
     private File projectDir;
 
     @BeforeAll
-    void copyProject(@TempDir Path projectDir) throws Exception {
-      copyProjectFromResources("test-projects/gradle-curiostack-plugin/tools/claat", projectDir);
-
-      this.projectDir = projectDir.toFile();
+    void copyProject() {
+      projectDir =
+          ResourceProjects.fromResources("test-projects/gradle-curiostack-plugin/tools/claat")
+              .toFile();
     }
 
     @Test
-    void normal(@TempDir Path gradleUserHome) {
-      var result =
-          GradleRunner.create()
-              .withProjectDir(projectDir)
-              .withArguments("toolsSetupClaat")
-              .withPluginClasspath()
-              .withTestKitDir(gradleUserHome.toFile())
-              .build();
-
-      assertThat(result.task(":toolsDownloadClaat").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-      assertThat(result.task(":toolsSetupClaat").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    void normal() {
+      Path gradleUserHome = GradleTempDirectories.create("tools-home");
+      assertThat(
+              GradleRunner.create()
+                  .withProjectDir(projectDir)
+                  .withArguments("toolsSetupClaat")
+                  .withPluginClasspath()
+                  .withTestKitDir(gradleUserHome.toFile()))
+          .builds()
+          .tasksDidSucceed(":toolsDownloadClaat", ":toolsSetupClaat");
 
       assertToolDirExists(gradleUserHome, "claat", ToolDependencies.getClaatVersion(project));
     }
@@ -91,25 +89,24 @@ class CuriostackPluginToolsTest {
     private File projectDir;
 
     @BeforeAll
-    void copyProject(@TempDir Path projectDir) throws Exception {
-      copyProjectFromResources(
-          "test-projects/gradle-curiostack-plugin/tools/claat-override-version", projectDir);
-
-      this.projectDir = projectDir.toFile();
+    void copyProject() {
+      projectDir =
+          ResourceProjects.fromResources(
+                  "test-projects/gradle-curiostack-plugin/tools/claat-override-version")
+              .toFile();
     }
 
     @Test
-    void normal(@TempDir Path gradleUserHome) {
-      var result =
-          GradleRunner.create()
-              .withProjectDir(projectDir)
-              .withArguments("toolsSetupClaat")
-              .withPluginClasspath()
-              .withTestKitDir(gradleUserHome.toFile())
-              .build();
-
-      assertThat(result.task(":toolsDownloadClaat").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-      assertThat(result.task(":toolsSetupClaat").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    void normal() {
+      Path gradleUserHome = GradleTempDirectories.create("tools-home");
+      assertThat(
+              GradleRunner.create()
+                  .withProjectDir(projectDir)
+                  .withArguments("toolsSetupClaat")
+                  .withPluginClasspath()
+                  .withTestKitDir(gradleUserHome.toFile()))
+          .builds()
+          .tasksDidSucceed(":toolsDownloadClaat", ":toolsSetupClaat");
 
       assertThat(ToolDependencies.getClaatVersion(project)).isNotEqualTo("1.0.4");
       assertToolDirExists(gradleUserHome, "claat", "1.0.4");

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/test/java/org/curioswitch/gradle/plugins/staticsite/StaticSitePluginTest.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/test/java/org/curioswitch/gradle/plugins/staticsite/StaticSitePluginTest.java
@@ -24,40 +24,32 @@
 
 package org.curioswitch.gradle.plugins.staticsite;
 
-import static org.curioswitch.common.testing.assertj.CurioAssertions.assertThat;
-import static org.curioswitch.gradle.plugins.testutil.ResourceProjects.copyProjectFromResources;
+import static org.curioswitch.gradle.testing.assertj.CurioGradleAssertions.assertThat;
 
 import java.nio.file.Path;
+import org.curioswitch.gradle.testing.ResourceProjects;
 import org.gradle.testkit.runner.GradleRunner;
-import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 class StaticSitePluginTest {
 
   private Path projectDir;
 
   @BeforeAll
-  void copyProject(@TempDir Path projectDir) throws Exception {
-    copyProjectFromResources("test-projects/gradle-static-site-plugin", projectDir);
-
-    this.projectDir = projectDir;
+  void copyProject() {
+    projectDir = ResourceProjects.fromResources("test-projects/gradle-static-site-plugin");
   }
 
   @Test
   void normal() {
-    var result =
-        GradleRunner.create()
-            .withProjectDir(projectDir.toFile())
-            .withArguments("build", "--stacktrace")
-            .withPluginClasspath()
-            .forwardOutput()
-            .build();
-
-    assertThat(result.task(":site1:buildSite").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-    assertThat(result.task(":site2:buildSite").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-    assertThat(result.task(":portal:mergeSite").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    assertThat(
+            GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withArguments("build", "--stacktrace")
+                .withPluginClasspath())
+        .builds()
+        .tasksDidSucceed(":site1:buildSite", ":site2:buildSite", ":portal:mergeSite");
 
     assertThat(projectDir.resolve("portal/build/site/index.html"))
         .hasSameContentAs(projectDir.resolve("portal/src/index.html"));

--- a/tools/gradle-plugins/gradle-test-helpers/build.gradle.kts
+++ b/tools/gradle-plugins/gradle-test-helpers/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api("org.curioswitch.curiostack:curio-testing-framework")
+
+    api(gradleTestKit())
+
+    implementation("com.google.guava:guava")
+}

--- a/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/GradleTempDirectories.java
+++ b/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/GradleTempDirectories.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.testing;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+/**
+ * Utilities for creating temporary folders under the build directory of a Gradle project. Gradle
+ * TestKit and JUnit5 temporary directories tend to have issues, and since we know when testing a
+ * Gradle plugin it is always in the context of a Gradle project, we instead create them in the
+ * build directory where they can be cleaned outside the context of the test - the test will not
+ * attempt to delete the files.
+ *
+ * <p>These utilities use the {@code -Dorg.curioswitch.curiostack.testing.buildDir} system property
+ * to know where the current project's build directory is. Add this property to your build by adding
+ * something like the following to your build script.
+ *
+ * <pre>{@code
+ * tasks.withType(Test::class) {
+ *     jvmArgs("-Dorg.curioswitch.curiostack.testing.buildDir=${buildDir}")
+ * }
+ * }</pre>
+ */
+public final class GradleTempDirectories {
+
+  /**
+   * Returns the {@link Path} pointing to a newly created directory under the current Gradle
+   * project's build directory starting with {@code prefix}.
+   */
+  public static Path create(String prefix) {
+    String buildDir = System.getProperty("org.curioswitch.curiostack.testing.buildDir", "");
+    checkState(
+        !buildDir.isBlank(),
+        "org.curioswitch.curiostack.testing.buildDir must be specified "
+            + "to create a Gradle temp directory. Did you add the directive to your build script?");
+    var tempDir = Paths.get(buildDir).resolve("tempdirs").resolve(prefix + "-" + UUID.randomUUID());
+    try {
+      return Files.createDirectories(tempDir);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Could not create temp directory.", e);
+    }
+  }
+
+  private GradleTempDirectories() {}
+}

--- a/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/ResourceProjects.java
+++ b/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/ResourceProjects.java
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.testing;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Utilities for working with projects contained in resources (e.g., src/test/resources, not java).
+ */
+public final class ResourceProjects {
+
+  private static final Splitter RESOURCE_SPLITTER = Splitter.on('/');
+
+  /**
+   * Copies the files under {@code resourcePath} into a temporary directory and returns the path to
+   * the directory. The directory is created under the project build directory and is not deleted by
+   * the test.
+   */
+  public static Path fromResources(String resourcePath) {
+    Path projectDir =
+        GradleTempDirectories.create(
+            "project-" + Iterables.getLast(RESOURCE_SPLITTER.splitToList(resourcePath)));
+    final Path resourceDir;
+    try {
+      resourceDir = Paths.get(Resources.getResource(resourcePath).toURI());
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Could not convert resource path to URI.");
+    }
+    try (var stream = Files.walk(resourceDir)) {
+      stream
+          .filter(path -> !path.equals(resourceDir))
+          .forEach(
+              path -> {
+                var destPath = projectDir.resolve(resourceDir.relativize(path));
+                try {
+                  if (Files.isDirectory(path)) {
+                    Files.createDirectory(destPath);
+                  } else {
+                    Files.copy(path, destPath);
+                  }
+                } catch (IOException e) {
+                  throw new UncheckedIOException("Could not copy test project file.", e);
+                }
+              });
+    } catch (IOException e) {
+      throw new UncheckedIOException("Could not copy project from resources.", e);
+    }
+    return projectDir;
+  }
+
+  private ResourceProjects() {}
+}

--- a/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/BuildResultAssert.java
+++ b/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/BuildResultAssert.java
@@ -1,0 +1,103 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.testing.assertj;
+
+import static org.curioswitch.common.testing.assertj.CurioAssertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.SoftAssertions;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.TaskOutcome;
+
+/** {@link AbstractObjectAssert} for assertions on {@link BuildResult}. */
+public class BuildResultAssert extends AbstractObjectAssert<BuildResultAssert, BuildResult> {
+
+  BuildResultAssert(BuildResult buildResult) {
+    super(buildResult, BuildResultAssert.class);
+  }
+
+  /** Asserts that the {@code tasks} succeeded during the build. */
+  public BuildResultAssert tasksDidSucceed(String... tasks) {
+    return tasksDidSucceed(ImmutableList.copyOf(tasks));
+  }
+
+  /** Asserts that the {@code tasks} succeeded during the build. */
+  public BuildResultAssert tasksDidSucceed(Iterable<String> tasks) {
+    tasksDidRun(tasks);
+    SoftAssertions.assertSoftly(
+        softly -> {
+          for (var task : tasks) {
+            BuildTask result = actual.task(task);
+            softly
+                .assertThat(result.getOutcome())
+                .as("Task %s did not succeed", task)
+                .isEqualTo(TaskOutcome.SUCCESS);
+          }
+        });
+    return this;
+  }
+
+  /** Asserts that the {@code tasks} ran during the build. */
+  public BuildResultAssert tasksDidRun(String... tasks) {
+    return tasksDidRun(ImmutableList.copyOf(tasks));
+  }
+
+  /** Asserts that the {@code tasks} succeeded during the build. */
+  public BuildResultAssert tasksDidRun(Iterable<String> tasks) {
+    SoftAssertions.assertSoftly(
+        softly -> {
+          for (var task : tasks) {
+            BuildTask result = actual.task(task);
+            softly.assertThat(result).as("Task %s did not run", task).isNotNull();
+          }
+        });
+    return this;
+  }
+
+  /** Asserts that the {@code tasks} ran during the build. */
+  public BuildResultAssert tasksDidNotRun(String... tasks) {
+    return tasksDidNotRun(ImmutableList.copyOf(tasks));
+  }
+
+  /** Asserts that the {@code tasks} succeeded during the build. */
+  public BuildResultAssert tasksDidNotRun(Iterable<String> tasks) {
+    SoftAssertions.assertSoftly(
+        softly -> {
+          for (var task : tasks) {
+            BuildTask result = actual.task(task);
+            softly.assertThat(result).as("Task %s did not run", task).isNull();
+          }
+        });
+    return this;
+  }
+
+  /** Asserts that the build result has output that contains {@code content}. */
+  public BuildResultAssert outputContains(String content) {
+    assertThat(actual.getOutput()).contains(content);
+    return this;
+  }
+}

--- a/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/CurioGradleAssertions.java
+++ b/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/CurioGradleAssertions.java
@@ -28,21 +28,15 @@ import org.curioswitch.common.testing.assertj.CurioAssertions;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 
-/**
- * Standard {@link CurioAssertions} along with assertions for working with Gradle tests.
- */
+/** Standard {@link CurioAssertions} along with assertions for working with Gradle tests. */
 public class CurioGradleAssertions extends CurioAssertions {
 
-  /**
-   * Returns a {@link GradleRunnerAssert} to assert the result of the executed build.
-   */
+  /** Returns a {@link GradleRunnerAssert} to assert the result of the executed build. */
   public static GradleRunnerAssert assertThat(GradleRunner runner) {
     return new GradleRunnerAssert(runner);
   }
 
-  /**
-   * Returns a {@link BuildResultAssert} to assert the provided {@code result}.
-   */
+  /** Returns a {@link BuildResultAssert} to assert the provided {@code result}. */
   public static BuildResultAssert assertThat(BuildResult result) {
     return new BuildResultAssert(result);
   }

--- a/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/CurioGradleAssertions.java
+++ b/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/CurioGradleAssertions.java
@@ -1,0 +1,51 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.testing.assertj;
+
+import org.curioswitch.common.testing.assertj.CurioAssertions;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+
+/**
+ * Standard {@link CurioAssertions} along with assertions for working with Gradle tests.
+ */
+public class CurioGradleAssertions extends CurioAssertions {
+
+  /**
+   * Returns a {@link GradleRunnerAssert} to assert the result of the executed build.
+   */
+  public static GradleRunnerAssert assertThat(GradleRunner runner) {
+    return new GradleRunnerAssert(runner);
+  }
+
+  /**
+   * Returns a {@link BuildResultAssert} to assert the provided {@code result}.
+   */
+  public static BuildResultAssert assertThat(BuildResult result) {
+    return new BuildResultAssert(result);
+  }
+
+  private CurioGradleAssertions() {}
+}

--- a/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/GradleRunnerAssert.java
+++ b/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/GradleRunnerAssert.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Choko (choko@curioswitch.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.curioswitch.gradle.testing.assertj;
+
+import org.assertj.core.api.AbstractAssert;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.gradle.testkit.runner.UnexpectedBuildSuccess;
+
+/**
+ * A {@link AbstractAssert} for asserting the result of a Gradle build executed with {@link
+ * GradleRunner}.
+ */
+public class GradleRunnerAssert extends AbstractAssert<GradleRunnerAssert, GradleRunner> {
+
+  GradleRunnerAssert(GradleRunner runner) {
+    super(runner, GradleRunnerAssert.class);
+  }
+
+  /** Executes the build for the current runner and asserts that it succeeds. */
+  public BuildResultAssert builds() {
+    try {
+      return new BuildResultAssert(actual.build());
+    } catch (UnexpectedBuildFailure e) {
+      failWithMessage(
+          "Build expected to succeed, but failed with output:%s",
+          e.getBuildResult().getOutput());
+      // Can't reach here.
+      throw new Error();
+    }
+  }
+
+  /** Executes the build for the current runner and asserts that it fails. */
+  public BuildResultAssert fails() {
+    try {
+      return new BuildResultAssert(actual.buildAndFail());
+    } catch (UnexpectedBuildSuccess e) {
+      failWithMessage(
+          "Build expected to fail, but succeeded with output:%s",
+          e.getBuildResult().getOutput());
+      // Can't reach here.
+      throw new Error();
+    }
+  }
+}

--- a/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/GradleRunnerAssert.java
+++ b/tools/gradle-plugins/gradle-test-helpers/src/main/java/org/curioswitch/gradle/testing/assertj/GradleRunnerAssert.java
@@ -45,8 +45,7 @@ public class GradleRunnerAssert extends AbstractAssert<GradleRunnerAssert, Gradl
       return new BuildResultAssert(actual.build());
     } catch (UnexpectedBuildFailure e) {
       failWithMessage(
-          "Build expected to succeed, but failed with output:%s",
-          e.getBuildResult().getOutput());
+          "Build expected to succeed, but failed with output:%s", e.getBuildResult().getOutput());
       // Can't reach here.
       throw new Error();
     }
@@ -58,8 +57,7 @@ public class GradleRunnerAssert extends AbstractAssert<GradleRunnerAssert, Gradl
       return new BuildResultAssert(actual.buildAndFail());
     } catch (UnexpectedBuildSuccess e) {
       failWithMessage(
-          "Build expected to fail, but succeeded with output:%s",
-          e.getBuildResult().getOutput());
+          "Build expected to fail, but succeeded with output:%s", e.getBuildResult().getOutput());
       // Can't reach here.
       throw new Error();
     }


### PR DESCRIPTION
- Temporary directories are created in the project's build directory instead of using junit to prevent interactions with TestKit
  - Tests work correctly on Windows
- Added assertj assertions for running gradle tests
  - Output printed if test fails, not if test succeeds