### PR TITLE
Enable app engine API in main project.

### DIFF
--- a/cluster/terraform/sysadmin/bootstrap/project.tf.yaml
+++ b/cluster/terraform/sysadmin/bootstrap/project.tf.yaml
@@ -43,6 +43,11 @@ resource:
       service: admin.googleapis.com
       lifecycle:
         prevent_destroy: true
+    primary-appengine:
+      project: "${google_project.primary_project.project_id}"
+      service: appengine.googleapis.com
+      lifecycle:
+        prevent_destroy: true
     primary-compute:
       project: "${google_project.primary_project.project_id}"
       service: compute.googleapis.com

--- a/developer-portal/build.gradle.kts
+++ b/developer-portal/build.gradle.kts
@@ -22,6 +22,8 @@
  * SOFTWARE.
  */
 
+// Kick build 1
+
 plugins {
     id("org.curioswitch.gradle-curio-static-site-plugin")
 }


### PR DESCRIPTION
Error message on CI when deploying seems to indicate the deploying project needs app engine enabled even if accessing a different one.