### PR TITLE
Install curl into java-cloud-builder to start migration to use get-jd…

### DIFF
--- a/tools/build-images/java-cloud-builder/Dockerfile
+++ b/tools/build-images/java-cloud-builder/Dockerfile
@@ -32,7 +32,7 @@ FROM openjdk:11-jdk-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python2.7-minimal libpython2.7-stdlib liblz4-tool \
-    libatomic1 bzip2 ca-certificates && \
+    libatomic1 bzip2 ca-certificates curl && \
     update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
…k.sh in CI as well.