### PR TITLE
Add support for static web assets

### DIFF
--- a/common/web/base-web/package.json
+++ b/common/web/base-web/package.json
@@ -73,6 +73,7 @@
     "commander": "2.20.0",
     "compression-webpack-plugin": "3.0.0",
     "connected-react-router": "6.5.2",
+    "copy-webpack-plugin": "5.0.4",
     "core-js": "3.1.4",
     "enzyme": "3.10.0",
     "enzyme-adapter-react-16": "1.14.0",
@@ -135,6 +136,7 @@
   },
   "devDependencies": {
     "@types/compression-webpack-plugin": "2.0.1",
+    "@types/copy-webpack-plugin": "5.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.5",
     "@types/eslint": "4.16.6",

--- a/common/web/base-web/src/dev/webpack/base.ts
+++ b/common/web/base-web/src/dev/webpack/base.ts
@@ -24,6 +24,7 @@
 
 import path from 'path';
 
+import CopyWebpackPlugin from 'copy-webpack-plugin';
 import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import { Configuration } from 'webpack';
 
@@ -183,6 +184,13 @@ function configure(options: any): Configuration {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
       mainFields: ['browser', 'module', 'jsnext:main', 'main'],
       plugins: [
+        new CopyWebpackPlugin([
+          {
+            from: 'app/shared/assets',
+            to: 'assets',
+            ignore: ['README.md'],
+          },
+        ]),
         new TsconfigPathsPlugin({
           extensions: ['.ts', '.tsx', '.js', '.jsx'],
           mainFields: ['browser', 'module', 'jsnext:main', 'main'],

--- a/common/web/base-web/src/dev/webpack/prod.ts
+++ b/common/web/base-web/src/dev/webpack/prod.ts
@@ -42,6 +42,7 @@ import path from 'path';
 import { gzip } from '@gfx/zopfli';
 import BrotliPlugin from 'brotli-webpack-plugin';
 import CompressionPlugin from 'compression-webpack-plugin';
+import CopyWebpackPlugin from 'copy-webpack-plugin';
 import FaviconPlugin from 'favicons-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { ReactLoadablePlugin } from 'react-loadable/webpack';
@@ -89,6 +90,14 @@ const plugins = [
     emitStats: true,
     statsFilename: 'iconstats.json',
   }),
+
+  new CopyWebpackPlugin([
+    {
+      from: 'app/shared/assets',
+      to: 'assets',
+      ignore: ['README.md'],
+    },
+  ]),
 
   new CompressionPlugin({
     filename: '[path].gz[query]',

--- a/common/web/base-web/src/dev/webpack/prod.ts
+++ b/common/web/base-web/src/dev/webpack/prod.ts
@@ -42,7 +42,6 @@ import path from 'path';
 import { gzip } from '@gfx/zopfli';
 import BrotliPlugin from 'brotli-webpack-plugin';
 import CompressionPlugin from 'compression-webpack-plugin';
-import CopyWebpackPlugin from 'copy-webpack-plugin';
 import FaviconPlugin from 'favicons-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { ReactLoadablePlugin } from 'react-loadable/webpack';
@@ -90,14 +89,6 @@ const plugins = [
     emitStats: true,
     statsFilename: 'iconstats.json',
   }),
-
-  new CopyWebpackPlugin([
-    {
-      from: 'app/shared/assets',
-      to: 'assets',
-      ignore: ['README.md'],
-    },
-  ]),
 
   new CompressionPlugin({
     filename: '[path].gz[query]',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,6 +1867,15 @@
   dependencies:
     "@types/node" "*"
 
+"@types/copy-webpack-plugin@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/copy-webpack-plugin/-/copy-webpack-plugin-5.0.0.tgz#db7f9c9763b10b2af5c83f598fa9b5a13733b20b"
+  integrity sha512-yQHocgdgES7W5Q2UyxJ5cj/E6MrV1zq3MZ8jdApS9NJKqax+rux9IE3QAbBmNCGbgivEsejrkIq3Rm76JLubkg==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+    "@types/webpack" "*"
+
 "@types/duplexify@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@types/duplexify/-/duplexify-3.6.0.tgz#dfc82b64bd3a2168f5bd26444af165bf0237dcd8"
@@ -4796,7 +4805,7 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
-cacache@^11.2.0, cacache@^11.3.2:
+cacache@^11.2.0, cacache@^11.3.2, cacache@^11.3.3:
   version "11.3.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.3.tgz#8bd29df8c6a718a6ebd2d010da4d7972ae3bbadc"
   integrity sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==
@@ -5640,6 +5649,24 @@ copy-to-clipboard@^3.0.8:
   dependencies:
     toggle-selection "^1.0.6"
 
+copy-webpack-plugin@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-5.0.4.tgz#c78126f604e24f194c6ec2f43a64e232b5d43655"
+  integrity sha512-YBuYGpSzoCHSSDGyHy6VJ7SHojKp6WHT4D7ItcQFNAYx2hrwkMe56e97xfVR0/ovDuMTrMffXUiltvQljtAGeg==
+  dependencies:
+    cacache "^11.3.3"
+    find-cache-dir "^2.1.0"
+    glob-parent "^3.1.0"
+    globby "^7.1.1"
+    is-glob "^4.0.1"
+    loader-utils "^1.2.3"
+    minimatch "^3.0.4"
+    normalize-path "^3.0.0"
+    p-limit "^2.2.0"
+    schema-utils "^1.0.0"
+    serialize-javascript "^1.7.0"
+    webpack-log "^2.0.0"
+
 copyfiles@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.1.1.tgz#d430e122d7880f92c45d372208b0af03b0c39db6"
@@ -6439,6 +6466,13 @@ dir-glob@2.0.0:
   integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
   dependencies:
     arrify "^1.0.1"
+    path-type "^3.0.0"
+
+dir-glob@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
+  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  dependencies:
     path-type "^3.0.0"
 
 discontinuous-range@1.0.0:
@@ -7890,7 +7924,7 @@ finalhandler@1.1.2, finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-cache-dir@^2.0.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -8580,6 +8614,18 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 glogg@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Probably preferable to serve things like social images from a public gcloud bucket or something but it's harder to commit changes to the source. Maybe adding assets to a gcloud bucket with terraform is a better option. What do you think?