### PR TITLE
Explicitly check for undefined when evaluating the payload of an action.

### DIFF
--- a/common/web/base-web/src/state/actions.ts
+++ b/common/web/base-web/src/state/actions.ts
@@ -38,7 +38,7 @@ export function createAction<T extends string, P>(
   payload: P,
 ): ActionWithPayload<T, P>;
 export function createAction<T extends string, P>(type: T, payload?: P) {
-  return payload ? { type, payload } : { type };
+  return payload === undefined ? { type, payload } : { type };
 }
 
 export type ActionsUnion<A extends ActionCreatorsMapObject> = ReturnType<


### PR DESCRIPTION
Sometimes we would like to pass `null` or `0` as a payload but they evaluate to false and do not get passed along.