### PR TITLE
Return only type when payload is undefined.

### DIFF
--- a/common/web/base-web/src/state/actions.ts
+++ b/common/web/base-web/src/state/actions.ts
@@ -38,7 +38,7 @@ export function createAction<T extends string, P>(
   payload: P,
 ): ActionWithPayload<T, P>;
 export function createAction<T extends string, P>(type: T, payload?: P) {
-  return payload === undefined ? { type, payload } : { type };
+  return payload === undefined ? { type } : { type, payload };
 }
 
 export type ActionsUnion<A extends ActionCreatorsMapObject> = ReturnType<


### PR DESCRIPTION
I'm sorry for this oversight. The change merged before and released in 0.47 broke _a lot_ of things :crying_cat_face: 