### PR TITLE
Fix URLs redirect to root.

### DIFF
--- a/cafe-map/client/web/package.json
+++ b/cafe-map/client/web/package.json
@@ -12,7 +12,7 @@
     }
   },
   "dependencies": {
-    "@curiostack/base-web": "0.0.44",
+    "@curiostack/base-web": "0.0.48",
     "@curiostack/cafemap-api": "1.0.0",
     "@material-ui/core": "4.2.1",
     "@material-ui/icons": "4.2.1",

--- a/common/web/base-web/package.json
+++ b/common/web/base-web/package.json
@@ -49,6 +49,7 @@
     "@storybook/addon-options": "5.1.9",
     "@storybook/addon-viewport": "5.1.9",
     "@storybook/react": "5.1.9",
+    "@types/enzyme": "3.10.3",
     "@types/history": "4.7.2",
     "@types/intl": "1.2.0",
     "@types/jest": "24.0.15",
@@ -137,7 +138,6 @@
   "devDependencies": {
     "@types/compression-webpack-plugin": "2.0.1",
     "@types/copy-webpack-plugin": "5.0.0",
-    "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.5",
     "@types/eslint": "4.16.6",
     "@types/fontfaceobserver": "0.0.6",

--- a/common/web/base-web/src/state/reducers.ts
+++ b/common/web/base-web/src/state/reducers.ts
@@ -33,7 +33,9 @@ import { InjectableStore } from './store';
 export interface RouterStateRecord extends Record<RouterState>, RouterState {}
 
 export const routeInitialState: RouterStateRecord = Record<RouterState>({
-  location: createLocation(window ? window.location : ''),
+  location: createLocation(
+    typeof window !== 'undefined' ? window.location : '',
+  ),
   action: 'POP',
 })();
 

--- a/common/web/base-web/src/state/reducers.ts
+++ b/common/web/base-web/src/state/reducers.ts
@@ -33,7 +33,7 @@ import { InjectableStore } from './store';
 export interface RouterStateRecord extends Record<RouterState>, RouterState {}
 
 export const routeInitialState: RouterStateRecord = Record<RouterState>({
-  location: createLocation(''),
+  location: createLocation(window.location.pathname),
   action: 'POP',
 })();
 

--- a/common/web/base-web/src/state/reducers.ts
+++ b/common/web/base-web/src/state/reducers.ts
@@ -33,7 +33,7 @@ import { InjectableStore } from './store';
 export interface RouterStateRecord extends Record<RouterState>, RouterState {}
 
 export const routeInitialState: RouterStateRecord = Record<RouterState>({
-  location: createLocation(window.location),
+  location: createLocation(window ? window.location : ''),
   action: 'POP',
 })();
 

--- a/common/web/base-web/src/state/reducers.ts
+++ b/common/web/base-web/src/state/reducers.ts
@@ -33,7 +33,7 @@ import { InjectableStore } from './store';
 export interface RouterStateRecord extends Record<RouterState>, RouterState {}
 
 export const routeInitialState: RouterStateRecord = Record<RouterState>({
-  location: createLocation(window.location.pathname),
+  location: createLocation(window.location),
   action: 'POP',
 })();
 

--- a/eggworld/client/web/package.json
+++ b/eggworld/client/web/package.json
@@ -17,7 +17,7 @@
     }
   },
   "dependencies": {
-    "@curiostack/base-web": "0.0.44",
+    "@curiostack/base-web": "0.0.48",
     "@curiostack/eggworld-api": "1.0.0",
     "howler": "2.1.2",
     "konva": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/runtime-corejs2": "7.5.5",
     "@babel/runtime-corejs3": "7.5.5",
     "@curiostack/base-node-dev": "0.0.16",
-    "@curiostack/base-web": "0.0.47",
+    "@curiostack/base-web": "0.0.48",
     "@curiostack/eslint-config-web": "0.0.2",
     "@gfx/zopfli": "1.0.14",
     "@hugmanrique/react-markdown-loader": "0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,7 +886,7 @@
     typescript "3.5.3"
 
 "@curiostack/base-web@0.0.44":
-  version "0.0.47"
+  version "0.0.48"
   dependencies:
     "@babel/core" "7.5.5"
     "@babel/plugin-proposal-async-generator-functions" "7.2.0"
@@ -912,6 +912,7 @@
     "@storybook/addon-options" "5.1.9"
     "@storybook/addon-viewport" "5.1.9"
     "@storybook/react" "5.1.9"
+    "@types/enzyme" "3.10.3"
     "@types/history" "4.7.2"
     "@types/intl" "1.2.0"
     "@types/jest" "24.0.15"


### PR DESCRIPTION
Using empty string seemed to have been ok in previous versions of connected-react-router but not anymore.