### PR TITLE
Catch up latest Armeria release

### DIFF
--- a/tools/curiostack-bom/build.gradle.kts
+++ b/tools/curiostack-bom/build.gradle.kts
@@ -193,8 +193,8 @@ val DEPENDENCY_SETS = listOf(
     ),
     DependencySet(
         "com.linecorp.armeria",
-        "0.87.0",
-        listOf("armeria", "armeria-grpc", "armeria-retrofit2", "armeria-zipkin")
+        "0.90.3",
+        listOf("armeria", "armeria-grpc", "armeria-retrofit2", "armeria-brave")
     ),
     DependencySet(
         "com.spotify",

--- a/tools/curiostack-bom/gradle.properties
+++ b/tools/curiostack-bom/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.11
+version = 0.0.12

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/ToolDependencies.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curiostack/ToolDependencies.java
@@ -33,7 +33,7 @@ public class ToolDependencies {
 
   private static Map<String, String> DEFAULT_VERSIONS =
       ImmutableMap.<String, String>builder()
-          .put("bom", "0.0.11")
+          .put("bom", "0.0.12")
           .put("claat", "2.1.2")
           .put("gcloud", "248.0.0")
           .put("golang", "1.12.5")


### PR DESCRIPTION
This is to catch up latest Armeria release to address HTTP/2 security issues recently found.