### PR TITLE
Only enable gcloud caching within project when gradle cache is enabled.

### DIFF
--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/gcloud/GcloudPlugin.java
@@ -231,7 +231,8 @@ public class GcloudPlugin implements Plugin<Project> {
 
     project.afterEvaluate(
         p -> {
-          if (System.getenv("CI") != null) {
+          if (System.getenv("CI") != null
+              && project.getGradle().getStartParameter().isBuildCacheEnabled()) {
             project
                 .getPlugins()
                 .withType(ToolDownloaderPlugin.class)


### PR DESCRIPTION
Fixes #446