### PR TITLE
Don't use auto-service for testing-framework extensions since we need…

### DIFF
--- a/common/testing/framework/build.gradle
+++ b/common/testing/framework/build.gradle
@@ -44,9 +44,6 @@ dependencies {
     implementation 'org.mockito:mockito-core'
     implementation 'org.mockito:mockito-junit-jupiter'
 
-    annotationProcessor 'com.google.auto.service:auto-service'
-    compileOnly 'com.google.auto.service:auto-service'
-
     annotationProcessor 'com.google.dagger:dagger-compiler'
 
     annotationProcessor 'org.immutables:value'

--- a/common/testing/framework/gradle.properties
+++ b/common/testing/framework/gradle.properties
@@ -22,4 +22,4 @@
 # SOFTWARE.
 #
 
-version = 0.0.16
+version = 0.0.17

--- a/common/testing/framework/src/main/java/org/curioswitch/common/testing/snapshot/SnapshotExtension.java
+++ b/common/testing/framework/src/main/java/org/curioswitch/common/testing/snapshot/SnapshotExtension.java
@@ -23,18 +23,15 @@
  */
 package org.curioswitch.common.testing.snapshot;
 
-import com.google.auto.service.AutoService;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * A Jupiter extension to read and write snapshots for use with snapshot assertions. All assertions
  * must be made from the test thread.
  */
-@AutoService(Extension.class)
 public class SnapshotExtension implements BeforeEachCallback, AfterEachCallback, AfterAllCallback {
 
   static final ThreadLocal<ExtensionContext> CURRENT_CONTEXT = new ThreadLocal<>();

--- a/common/testing/framework/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/common/testing/framework/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -22,4 +22,5 @@
 # SOFTWARE.
 #
 
+org.curioswitch.common.testing.snapshot.SnapshotExtension
 org.mockito.junit.jupiter.MockitoExtension


### PR DESCRIPTION
… to merge with the external MockitoExtension.