### PR TITLE
Use UNSAFE_componentWillMount when injecting sagas and reducers.

### DIFF
--- a/common/web/base-web/src/hoc/injectReducer.tsx
+++ b/common/web/base-web/src/hoc/injectReducer.tsx
@@ -43,7 +43,7 @@ interface HocProps {
  * @param {string} key A key of the reducer
  * @param {function} reducer A reducer that will be injected
  *
- * Deprecated - this HOC will be deleted when React 17 is released. Migrate to hooks and useSaga before then.
+ * Deprecated - this HOC will be deleted when React 17 is released. Migrate to hooks and useReducer before then.
  *
  */
 export default ({ key, reducer }: Options) => <TOriginalProps extends {}>(

--- a/common/web/base-web/src/hoc/injectReducer.tsx
+++ b/common/web/base-web/src/hoc/injectReducer.tsx
@@ -43,6 +43,8 @@ interface HocProps {
  * @param {string} key A key of the reducer
  * @param {function} reducer A reducer that will be injected
  *
+ * Deprecated - this HOC will be deleted when React 17 is released. Migrate to hooks and useSaga before then.
+ *
  */
 export default ({ key, reducer }: Options) => <TOriginalProps extends {}>(
   WrappedComponent:
@@ -57,7 +59,8 @@ export default ({ key, reducer }: Options) => <TOriginalProps extends {}>(
 
     private injectors = getInjectors(this.props.reduxCtx.store as any);
 
-    public componentDidMount() {
+    // eslint-disable-next-line camelcase
+    public UNSAFE_componentWillMount() {
       const { injectReducer } = this.injectors;
       injectReducer(key, reducer);
     }

--- a/common/web/base-web/src/hoc/injectSaga.tsx
+++ b/common/web/base-web/src/hoc/injectSaga.tsx
@@ -47,6 +47,8 @@ interface HocProps {
  *   - constants.DAEMON—starts the saga on component mount and never cancels it or starts again,
  *   - constants.ONCE_TILL_UNMOUNT—behaves like 'RESTART_ON_REMOUNT' but never runs it again.
  *
+ * Deprecated - this HOC will be deleted when React 17 is released. Migrate to hooks and useSaga before then.
+ *
  */
 export default ({ key, saga, mode }: Options) => <TOriginalProps extends {}>(
   WrappedComponent:

--- a/common/web/base-web/src/hoc/injectSaga.tsx
+++ b/common/web/base-web/src/hoc/injectSaga.tsx
@@ -61,7 +61,8 @@ export default ({ key, saga, mode }: Options) => <TOriginalProps extends {}>(
 
     private injectors = getInjectors(this.props.reduxCtx.store as any);
 
-    public componentDidMount() {
+    // eslint-disable-next-line camelcase
+    public UNSAFE_componentWillMount() {
       const { injectSaga } = this.injectors;
 
       injectSaga(key, { saga, mode }, this.props);


### PR DESCRIPTION
This reverts a change introduced in base-web 0.1.0 in order to prevent ordering issues.