### PR TITLE
Enable eggworld API javadoc task.

### DIFF
--- a/eggworld/api/build.gradle
+++ b/eggworld/api/build.gradle
@@ -30,6 +30,3 @@ grpc {
     web.set(true)
     webPackageName.set('@curiostack/eggworld-api')
 }
-
-// TODO(choko): Reenable after https://github.com/protocolbuffers/protobuf/pull/6802 is released
-tasks.javadoc.enabled = false


### PR DESCRIPTION
Just to prove this isn't required anymore after upgrading protobuf to 3.11.1.