### PR TITLE
Use correct HttpStatus for successful cloud storage file deletion.

### DIFF
--- a/common/google-cloud/cloud-storage/src/main/java/org/curioswitch/curiostack/gcloud/storage/StorageClient.java
+++ b/common/google-cloud/cloud-storage/src/main/java/org/curioswitch/curiostack/gcloud/storage/StorageClient.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
@@ -226,7 +227,7 @@ public class StorageClient {
               if (t != null) {
                 throw new RuntimeException("Unexpected error deleting file.", t);
               }
-              if (msg.status().equals(HttpStatus.NO_CONTENT)) {
+              if (msg.status().codeClass().equals(HttpStatusClass.SUCCESS)) {
                 return null;
               } else {
                 throw new IllegalStateException(

--- a/common/google-cloud/cloud-storage/src/main/java/org/curioswitch/curiostack/gcloud/storage/StorageClient.java
+++ b/common/google-cloud/cloud-storage/src/main/java/org/curioswitch/curiostack/gcloud/storage/StorageClient.java
@@ -226,7 +226,7 @@ public class StorageClient {
               if (t != null) {
                 throw new RuntimeException("Unexpected error deleting file.", t);
               }
-              if (msg.status().equals(HttpStatus.OK)) {
+              if (msg.status().equals(HttpStatus.NO_CONTENT)) {
                 return null;
               } else {
                 throw new IllegalStateException(


### PR DESCRIPTION
Successful delete are throwing exceptions without any content. I've confirmed inside the bucket that the files have indeed been deleted.

I can't find actual documentation in the REST API docs, but the official XML docs and various code samples online state that 204/NO_CONTENT is returned when a successful delete happens.

https://cloud.google.com/storage/docs/xml-api/delete-object