### PR TITLE
Override JVM version for test classpaths to support gradle metadata.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,19 @@ allprojects {
 
     plugins.withId('java') {
         task allDeps(type: DependencyReportTask) {}
+
+        configurations {
+            testCompileClasspath {
+                attributes {
+                    attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
+                }
+            }
+            testRuntimeClasspath {
+                attributes {
+                    attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 11)
+                }
+            }
+        }
     }
 
     plugins.withType(org.gradle.api.publish.maven.plugins.MavenPublishPlugin) {


### PR DESCRIPTION
Gradle correctly finds our Java 8 modules our depending on a Java 11 module in the test classpath. Test should be allowed to be Java 11 regardless of the target for the sources.