### PR TITLE
Use URI authority when parsing endpoint.

### DIFF
--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/armeria/ClientBuilderFactory.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/armeria/ClientBuilderFactory.java
@@ -170,8 +170,8 @@ public class ClientBuilderFactory {
       endpoint = endpointGroup;
     }
 
-    ClientBuilder builder = Clients.builder(uri.getScheme(), endpoint).factory(clientFactory);
-
+    ClientBuilder builder =
+        Clients.builder(uri.getScheme(), endpoint).factory(clientFactory).path(uri.getPath());
     return builder
         .decorator(
             MetricCollectingClient.newDecorator(RpcMetricLabels.grpcRequestLabeler("grpc_clients")))

--- a/common/server/framework/src/main/java/org/curioswitch/common/server/framework/armeria/ClientBuilderFactory.java
+++ b/common/server/framework/src/main/java/org/curioswitch/common/server/framework/armeria/ClientBuilderFactory.java
@@ -149,7 +149,7 @@ public class ClientBuilderFactory {
 
   public ClientBuilder create(String name, String url) {
     URI uri = URI.create(url);
-    EndpointGroup endpoint = Endpoint.parse(url);
+    EndpointGroup endpoint = Endpoint.parse(uri.getAuthority());
     if (((Endpoint) endpoint).authority().endsWith("cluster.local")) {
       DnsAddressEndpointGroup dnsEndpointGroup =
           DnsAddressEndpointGroup.builder(uri.getHost()).port(uri.getPort()).ttl(1, 10).build();


### PR DESCRIPTION
When starting a service that builds a grpc client to connect to another service, an error is thrown

```
Exception in thread "main" java.lang.IllegalArgumentException: Not a valid domain name: 'gproto+https://developer-gateway.mydomain.com:8080/api/'
```
Looking at https://github.com/line/armeria/blob/master/core/src/main/java/com/linecorp/armeria/client/Endpoint.java#L81 it looks like the authority should be passed in instead of the full URI.

I tried to test the change in this repo using the Instagram scraper but I didn't have the necessary configs set up (db, API keys).