### PR TITLE
support proto version 2 for armeria

### DIFF
--- a/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/ProtoFieldInfo.java
+++ b/common/grpc/protobuf-jackson/src/main/java/org/curioswitch/common/protobuf/json/ProtoFieldInfo.java
@@ -133,7 +133,7 @@ class ProtoFieldInfo {
    */
   Message valuePrototype() {
     Message nestedPrototype =
-        containingPrototype.newBuilderForType().newBuilderForField(field).build();
+        containingPrototype.newBuilderForType().newBuilderForField(field).buildPartial();
     if (isMapField()) {
       // newBuilderForField will give us the Message corresponding to the map with key and value,
       // but we want the marshaller for the value itself.
@@ -336,7 +336,7 @@ class ProtoFieldInfo {
         return containingPrototype
             .newBuilderForType()
             .newBuilderForField(valueField().descriptor())
-            .build()
+            .buildPartial()
             .getClass();
       default:
         throw new IllegalArgumentException("Unknown field type: " + valueJavaType());


### PR DESCRIPTION
Armeria uses curiostack/protobuf-jackson as DefaultJsonMarshaller to support gjson or gjson-web format. When using proto version 2 with required field in Armeria, try to support gjson or gjson-web, an error occurred when initializing FramedGrpcService and cannot be executed. if protobuf-jackson call `buildPartial` instead of `build`, can be support proto version 2 required field

https://github.com/line/armeria/issues/3273