### PR TITLE
Add jgit.ssh.jsch bundle dep to the bom

### DIFF
--- a/tools/curiostack-bom/build.gradle.kts
+++ b/tools/curiostack-bom/build.gradle.kts
@@ -284,7 +284,7 @@ val DEPENDENCY_SETS = listOf(
         DependencySet(
                 "org.eclipse.jgit",
                 "5.10.0.202012080955-r",
-                listOf("org.eclipse.jgit")
+                listOf("org.eclipse.jgit, org.eclipse.jgit.ssh.jsch")
         ),
         DependencySet(
                 "org.immutables",


### PR DESCRIPTION
Before the curiostack 0.6.0 update `org.eclipse.jgit` was upgraded [from 5.7 to 5.8](https://github.com/curioswitch/curiostack/commit/fa5eab68884c124d983ed7d4903668ff33d73eae#diff-9b64b25492de5007587b7ef5daf56eda77d8c6dffe77d2e44609364cf7b5d6aaR275). While reading the [changelog for 5.8](https://wiki.eclipse.org/JGit/New_and_Noteworthy/5.8), it mentioned that it split the ssh (and some other) dependencies to separate bundles.

In our project we use `org.ajoberstar.git-publish` which depends on jgit and I believe the upgraded version in the curio bom is preventing the tool from working properly similar to what is mentioned in the eclipse bug tracker: https://bugs.eclipse.org/bugs/show_bug.cgi?id=566260.

```
Step #1: Caused by: org.eclipse.jgit.api.errors.TransportException: git@github.com:myorg/project.git: remote hung up unexpectedly
Step #1: 	at org.eclipse.jgit.api.LsRemoteCommand.execute(LsRemoteCommand.java:189)
Step #1: 	at org.eclipse.jgit.api.LsRemoteCommand.call(LsRemoteCommand.java:128)
Step #1: 	at org.eclipse.jgit.api.LsRemoteCommand.call(LsRemoteCommand.java:1)
Step #1: 	at java_util_concurrent_Callable$call$0.call(Unknown Source)
Step #1: 	at org.ajoberstar.grgit.operation.LsRemoteOp.call(LsRemoteOp.groovy:38)
Step #1: 	at org.ajoberstar.grgit.operation.LsRemoteOp.call(LsRemoteOp.groovy)
Step #1: 	at java_util_concurrent_Callable$call.call(Unknown Source)
Step #1: 	at java_util_concurrent_Callable$call.call(Unknown Source)
Step #1: 	at org.ajoberstar.grgit.internal.OpSyntax.samOperation(OpSyntax.groovy:26)
Step #1: 	at org.ajoberstar.grgit.internal.OpSyntax$samOperation.callStatic(Unknown Source)
Step #1: 	at org.ajoberstar.grgit.Grgit.lsremote(Grgit.groovy)
Step #1: 	at org.ajoberstar.gradle.git.publish.tasks.GitPublishReset.reset(GitPublishReset.java:111)
Step #1: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
Step #1: 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
Step #1: 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
Step #1: 	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:104)
Step #1: 	... 94 more
Step #1: Caused by: org.eclipse.jgit.errors.TransportException: git@github.com:myorg/project.git: remote hung up unexpectedly
Step #1: 	at org.eclipse.jgit.transport.TransportGitSsh$SshFetchConnection.<init>(TransportGitSsh.java:270)
Step #1: 	at org.eclipse.jgit.transport.TransportGitSsh.openFetch(TransportGitSsh.java:144)
Step #1: 	at org.eclipse.jgit.api.LsRemoteCommand.execute(LsRemoteCommand.java:167)
Step #1: 	... 109 more
Step #1: Caused by: java.lang.NullPointerException
Step #1: 	at org.eclipse.jgit.transport.SshTransport.getSession(SshTransport.java:107)
Step #1: 	at org.eclipse.jgit.transport.TransportGitSsh$SshFetchConnection.<init>(TransportGitSsh.java:254)
Step #1: 	... 111 more
```

I'm not sure if you wanted to include this new bundle or not but in interest of not causing breakage from the version bump, I'm submitting this PR to get some feedback. 
