### PR TITLE
Upgrade jib-gradle-plugin to v2.8.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,7 +46,7 @@ pluginManagement {
 
 plugins {
     id("com.gradle.enterprise").version("3.5.2")
-    id("org.curioswitch.gradle-curiostack-plugin").version("0.7.0")
+    id("org.curioswitch.gradle-curiostack-plugin").version("0.7.1")
 }
 
 configure<CuriostackExtension> {

--- a/tools/curiostack-bom/build.gradle.kts
+++ b/tools/curiostack-bom/build.gradle.kts
@@ -342,7 +342,7 @@ val DEPENDENCIES = listOf(
         "com.uber.nullaway:nullaway:0.9.0",
         "de.undercouch:gradle-download-task:4.1.1",
         "gradle.plugin.com.boxfuse.client:gradle-plugin-publishing:6.0.6",
-        "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:2.1.0",
+        "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:2.8.0",
         "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.2.4",
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0",
         "io.sgr:s2-geometry-library-java:1.0.1",

--- a/tools/gradle-plugins/gradle-curiostack-plugin/build.gradle.kts
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation("com.github.ben-manes:gradle-versions-plugin")
     implementation("com.google.auth:google-auth-library-oauth2-http")
     implementation("com.google.cloud:google-cloud-kms")
+    implementation("com.google.cloud.tools:jib-build-plan:0.4.0")
     implementation("com.google.guava:guava")
     implementation("com.hubspot.jinjava:jinjava")
     implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin")

--- a/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/CurioServerPlugin.java
+++ b/tools/gradle-plugins/gradle-curiostack-plugin/src/main/java/org/curioswitch/gradle/plugins/curioserver/CurioServerPlugin.java
@@ -23,7 +23,7 @@
  */
 package org.curioswitch.gradle.plugins.curioserver;
 
-import com.google.cloud.tools.jib.api.ImageFormat;
+import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.gradle.BuildImageTask;
 import com.google.cloud.tools.jib.gradle.JibExtension;
 import com.google.cloud.tools.jib.gradle.JibPlugin;

--- a/tools/gradle-plugins/gradle-golang-plugin/build.gradle.kts
+++ b/tools/gradle-plugins/gradle-golang-plugin/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(project(":tools:gradle-plugins:gradle-tool-downloader-plugin"))
     implementation(project(":tools:gradle-plugins:gradle-helpers"))
 
+    implementation("com.google.cloud.tools:jib-build-plan:0.4.0")
     implementation("com.google.guava:guava")
     implementation("gradle.plugin.com.google.cloud.tools:jib-gradle-plugin")
 

--- a/tools/gradle-plugins/gradle-golang-plugin/src/main/java/org/curioswitch/gradle/golang/tasks/JibTask.java
+++ b/tools/gradle-plugins/gradle-golang-plugin/src/main/java/org/curioswitch/gradle/golang/tasks/JibTask.java
@@ -38,16 +38,16 @@
  */
 package org.curioswitch.gradle.golang.tasks;
 
-import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.Containerizer;
-import com.google.cloud.tools.jib.api.FilePermissions;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LayerConfiguration;
 import com.google.cloud.tools.jib.api.LogEvent;
-import com.google.cloud.tools.jib.api.Port;
 import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
+import com.google.cloud.tools.jib.api.buildplan.Port;
 import com.google.cloud.tools.jib.event.events.ProgressEvent;
 import com.google.cloud.tools.jib.event.events.TimerEvent;
 import com.google.cloud.tools.jib.event.progress.ProgressEventHandler;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,6 +2679,11 @@
   resolved "https://registry.yarnpkg.com/@types/npmlog/-/npmlog-4.1.2.tgz#d070fe6a6b78755d1092a3dc492d34c3d8f871c4"
   integrity sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA==
 
+"@types/nunjucks@3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/nunjucks/-/nunjucks-3.1.4.tgz#2f80e2fa5e7982b2131201d0b4474ab4d03d9de1"
+  integrity sha512-cR65PLlHKW/qxxj840dbNb3ICO+iAVQzaNKJ8TcKOVKFi+QcAkhw9SCY8VFAyU41SmJMs+2nrIN2JGhX+jYb7A==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
For curiostack v0.7.1, `jackson v2.12.1` is not compatible with `jib-gradle-plugin v2.1.0` so the jib task fails. This is an attempt to upgrade jib to the latest v2.8.0.

Two things:
1. I needed to include the `jib-build-plan` dependency for `jib-core` in the modules because it is not being imported transitively, so even if I change the jib dependency configuration to "api", it does not work (https://github.com/GoogleContainerTools/jib/blob/5c5cf90c6d82ea7b7f21a7c1513da1ee8d7b9a54/build.gradle#L374). Do you think this is intentional or should we open an issue?

2. This test is failling but you might have a quicker fix than if I tried to solve it
```
GolangPluginTest > CanSetEnvironmentVariable > setEnvironmentVariable() STANDARD_ERROR
    SLF4J: Class path contains multiple SLF4J bindings.
    SLF4J: Found binding in [jar:file:/Users/bwoo/.gradle/caches/6.8.3/generated-gradle-jars/gradle-api-6.8.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
    SLF4J: Found binding in [jar:file:/Users/bwoo/.gradle/caches/modules-2/files-2.1/org.apache.logging.log4j/log4j-slf4j-impl/2.14.0/d6003a3b3f24fdb476848f4ecabdb2a43354e410/log4j-slf4j-impl-2.14.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
```

I was able to publish curiostack to maven local repo and confirmed that the my project jib task works with v2.8.0, without having to do significant code changes.

